### PR TITLE
Fix SWA 404 on refresh: include staticwebapp.config.json in build output

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -49,7 +49,8 @@
               {
                 "glob": "**/*",
                 "input": "public"
-              }
+              },
+              "staticwebapp.config.json"
             ],
             "styles": ["src/styles.css"],
             "server": "src/main.server.ts",


### PR DESCRIPTION
The navigation fallback config existed but wasn't listed in angular.json assets, so it never made it into dist/frontend/browser/. SWA served raw 404s for any deep link or page refresh since it had no fallback rule.