### PR TITLE
Fix SWA deploy: replace ** with * in navigationFallback exclude

### DIFF
--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -2,7 +2,7 @@
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": [
-      "/assets/**",
+      "/assets/*",
       "/*.css",
       "/*.js",
       "/*.ico",


### PR DESCRIPTION
Azure Static Web Apps rejects paths with multiple wildcard characters. Changed /assets/** to /assets/* which covers the flat asset directory.