### PR TITLE
Add Teams list + team profile pages

### DIFF
--- a/backend/src/HockeyHub.Api/Controllers/TeamsController.cs
+++ b/backend/src/HockeyHub.Api/Controllers/TeamsController.cs
@@ -1,0 +1,39 @@
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Queries;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class TeamsController(TeamsQueryService teamsQuery, HockeyHubDbContext db) : ControllerBase
+{
+    [HttpGet("leagues/{leagueId}/teams")]
+    public async Task<IActionResult> GetTeams(string leagueId, CancellationToken ct = default)
+    {
+        var id = await ResolveLeagueId(leagueId, ct);
+        if (id is null) return NotFound("League not found");
+
+        var result = await teamsQuery.GetTeamsAsync(id.Value, ct);
+        return Ok(result);
+    }
+
+    [HttpGet("teams/{teamId:int}")]
+    public async Task<IActionResult> GetTeamProfile(int teamId, CancellationToken ct = default)
+    {
+        var result = await teamsQuery.GetTeamProfileAsync(teamId, ct);
+        if (result is null) return NotFound("Team not found");
+        return Ok(result);
+    }
+
+    private async Task<int?> ResolveLeagueId(string leagueId, CancellationToken ct)
+    {
+        if (int.TryParse(leagueId, out var numericId))
+            return numericId;
+
+        var league = await db.Leagues
+            .FirstOrDefaultAsync(l => l.Abbreviation.ToLower() == leagueId.ToLower(), ct);
+        return league?.Id;
+    }
+}

--- a/backend/src/HockeyHub.Api/Program.cs
+++ b/backend/src/HockeyHub.Api/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddScoped<DataSeedService>();
 builder.Services.AddScoped<ScoresQueryService>();
 builder.Services.AddScoped<StandingsQueryService>();
 builder.Services.AddScoped<ScheduleQueryService>();
+builder.Services.AddScoped<TeamsQueryService>();
 builder.Services.AddScoped<ScoresSyncJob>();
 builder.Services.AddScoped<StandingsSyncJob>();
 builder.Services.AddScoped<ScheduleSyncJob>();

--- a/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
@@ -1,0 +1,178 @@
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Cache;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Data.Services.Queries;
+
+public class TeamsQueryService(HockeyHubDbContext db, RedisCacheService cache)
+{
+    public async Task<TeamsListResponse?> GetTeamsAsync(int leagueId, CancellationToken ct = default)
+    {
+        var cacheKey = $"teams:list:{leagueId}";
+
+        var teams = await cache.GetOrSetAsync(cacheKey, async _ =>
+        {
+            var season = await db.Seasons
+                .Where(s => s.LeagueId == leagueId && s.IsCurrent)
+                .FirstOrDefaultAsync(ct);
+
+            var teamEntities = await db.Teams
+                .Where(t => t.LeagueId == leagueId && t.IsActive)
+                .OrderBy(t => t.LocationName)
+                .ToListAsync(ct);
+
+            var standings = season is not null
+                ? await db.StandingsSnapshots
+                    .Where(s => s.SeasonId == season.Id)
+                    .ToDictionaryAsync(s => s.TeamId, ct)
+                : new();
+
+            return teamEntities.Select(t =>
+            {
+                standings.TryGetValue(t.Id, out var s);
+                return new TeamsListItemDto(
+                    Id: t.Id,
+                    LocationName: t.LocationName,
+                    Name: t.Name,
+                    Abbreviation: t.Abbreviation,
+                    LogoUrl: t.LogoUrl,
+                    PrimaryColor: t.PrimaryColor,
+                    Division: s?.Division,
+                    Conference: s?.Conference,
+                    Record: s is not null ? $"{s.Wins}-{s.Losses}-{s.OvertimeLosses}" : null,
+                    Points: s?.Points,
+                    PointsPct: s?.PointsPct
+                );
+            }).ToList();
+        }, RedisCacheService.TeamsTtl, ct);
+
+        return new TeamsListResponse(teams ?? []);
+    }
+
+    public async Task<TeamProfileResponse?> GetTeamProfileAsync(int teamId, CancellationToken ct = default)
+    {
+        var cacheKey = $"teams:profile:{teamId}";
+
+        return await cache.GetOrSetAsync(cacheKey, async _ =>
+        {
+            var team = await db.Teams
+                .Include(t => t.FranchiseHistories.OrderBy(f => f.YearStart))
+                .FirstOrDefaultAsync(t => t.Id == teamId, ct);
+
+            if (team is null) return null;
+
+            var season = await db.Seasons
+                .Where(s => s.LeagueId == team.LeagueId && s.IsCurrent)
+                .FirstOrDefaultAsync(ct);
+
+            var standings = season is not null
+                ? await db.StandingsSnapshots
+                    .FirstOrDefaultAsync(s => s.SeasonId == season.Id && s.TeamId == teamId, ct)
+                : null;
+
+            var roster = await db.Players
+                .Where(p => p.CurrentTeamId == teamId && p.IsActive)
+                .OrderBy(p => p.LastName).ThenBy(p => p.FirstName)
+                .Select(p => new RosterPlayerDto(
+                    PlayerId: p.Id,
+                    FirstName: p.FirstName,
+                    LastName: p.LastName,
+                    JerseyNumber: p.JerseyNumber,
+                    ShootsCatches: p.ShootsCatches,
+                    BirthCity: p.BirthCity,
+                    BirthCountry: p.BirthCountry,
+                    DateOfBirth: p.DateOfBirth,
+                    DraftYear: p.DraftYear,
+                    IsEbug: p.IsEbug
+                ))
+                .ToListAsync(ct);
+
+            return new TeamProfileResponse(
+                Id: team.Id,
+                LocationName: team.LocationName,
+                Name: team.Name,
+                Abbreviation: team.Abbreviation,
+                LogoUrl: team.LogoUrl,
+                PrimaryColor: team.PrimaryColor,
+                Division: standings?.Division,
+                Conference: standings?.Conference,
+                CurrentSeasonRecord: standings is not null
+                    ? new TeamRecordDto(standings.Wins, standings.Losses, standings.OvertimeLosses)
+                    : null,
+                Points: standings?.Points,
+                PointsPct: standings?.PointsPct,
+                LeagueRank: standings?.LeagueRank,
+                DivisionRank: standings?.DivisionRank,
+                JoinedSeasonYear: team.JoinedSeasonYear,
+                OriginalJoinYear: team.OriginalJoinYear,
+                StanleyCups: new StanleyCupsDto(team.StanleyCupsTotal, team.StanleyCupsSince1973, team.StanleyCupsSince2006),
+                FranchiseHistory: team.FranchiseHistories.Select(f => new FranchiseHistoryDto(
+                    f.PreviousLocationName, f.PreviousName, f.YearStart, f.YearEnd
+                )).ToList(),
+                Season: season?.Label,
+                Roster: roster,
+                DataAsOf: DateTimeOffset.UtcNow
+            );
+        }, RedisCacheService.RosterTtl, ct);
+    }
+}
+
+// ── List DTOs ──────────────────────────────────────────────────────────────────
+
+public record TeamsListResponse(IReadOnlyList<TeamsListItemDto> Teams);
+
+public record TeamsListItemDto(
+    int Id,
+    string LocationName,
+    string Name,
+    string Abbreviation,
+    string? LogoUrl,
+    string PrimaryColor,
+    string? Division,
+    string? Conference,
+    string? Record,
+    int? Points,
+    decimal? PointsPct
+);
+
+// ── Profile DTOs ───────────────────────────────────────────────────────────────
+
+public record TeamProfileResponse(
+    int Id,
+    string LocationName,
+    string Name,
+    string Abbreviation,
+    string? LogoUrl,
+    string PrimaryColor,
+    string? Division,
+    string? Conference,
+    TeamRecordDto? CurrentSeasonRecord,
+    int? Points,
+    decimal? PointsPct,
+    int? LeagueRank,
+    int? DivisionRank,
+    int JoinedSeasonYear,
+    int OriginalJoinYear,
+    StanleyCupsDto StanleyCups,
+    IReadOnlyList<FranchiseHistoryDto> FranchiseHistory,
+    string? Season,
+    IReadOnlyList<RosterPlayerDto> Roster,
+    DateTimeOffset DataAsOf
+);
+
+public record TeamRecordDto(int Wins, int Losses, int OvertimeLosses);
+public record StanleyCupsDto(int Total, int Since1973, int Since2006);
+public record FranchiseHistoryDto(string City, string Name, int YearStart, int YearEnd);
+
+public record RosterPlayerDto(
+    int PlayerId,
+    string FirstName,
+    string LastName,
+    int? JerseyNumber,
+    string ShootsCatches,
+    string BirthCity,
+    string BirthCountry,
+    DateOnly DateOfBirth,
+    int? DraftYear,
+    bool IsEbug
+);

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,7 @@ export const routes: Routes = [
   { path: ':leagueId/stats', loadComponent: () => import('./components/stats/stats-page/stats-page').then(m => m.StatsPage) },
   { path: ':leagueId/players', loadComponent: () => import('./components/players/players-page/players-page').then(m => m.PlayersPage) },
   { path: ':leagueId/teams', loadComponent: () => import('./components/teams/teams-index/teams-index').then(m => m.TeamsIndex) },
+  { path: ':leagueId/teams/:teamId', loadComponent: () => import('./components/teams/team-profile/team-profile').then(m => m.TeamProfilePage) },
   { path: ':leagueId/schedule', loadComponent: () => import('./components/schedule/schedule-page/schedule-page').then(m => m.SchedulePage) },
   { path: ':leagueId/salary-cap', loadComponent: () => import('./components/salary-cap/cap-overview/cap-overview').then(m => m.CapOverview) },
   { path: ':leagueId/trades', loadComponent: () => import('./components/trades/trades-list/trades-list').then(m => m.TradesList) },

--- a/frontend/src/app/components/layout/banner/banner.ts
+++ b/frontend/src/app/components/layout/banner/banner.ts
@@ -138,7 +138,7 @@ export class Banner {
 
   goToTeam(teamId: number): void {
     this.close();
-    this.router.navigate(['/', DEFAULT_LEAGUE_ID, 'teams'], { queryParams: { team: teamId } });
+    this.router.navigate(['/', DEFAULT_LEAGUE_ID, 'teams', teamId]);
   }
 
   goToPlayer(playerId: number): void {

--- a/frontend/src/app/components/teams/team-profile/team-profile.ts
+++ b/frontend/src/app/components/teams/team-profile/team-profile.ts
@@ -1,0 +1,184 @@
+import { Component, inject, signal, OnInit, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TeamsApiService, TeamProfile } from '../../../services/teams-api.service';
+import { DEFAULT_LEAGUE_ID } from '../../../constants';
+
+@Component({
+  selector: 'app-team-profile',
+  imports: [RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="profile-page">
+      @if (errorMessage()) {
+        <div class="state-msg state-error">{{ errorMessage() }}</div>
+      } @else if (loading()) {
+        <div class="state-msg">Loading team...</div>
+      } @else if (team(); as t) {
+        <header class="profile-header">
+          @if (t.logoUrl) {
+            <img [src]="t.logoUrl" [alt]="t.abbreviation" class="profile-logo" />
+          }
+          <div>
+            <h1 class="profile-title">{{ t.locationName }} {{ t.name }}</h1>
+            <div class="profile-meta">
+              {{ t.abbreviation }}
+              @if (t.division) { &middot; {{ t.division }} Division }
+              @if (t.conference) { &middot; {{ t.conference }} Conference }
+            </div>
+            @if (t.currentSeasonRecord; as r) {
+              <div class="profile-record">
+                {{ r.wins }}-{{ r.losses }}-{{ r.overtimeLosses }} &middot; {{ t.points }} pts
+                @if (t.divisionRank) { &middot; {{ ordinal(t.divisionRank) }} in division }
+              </div>
+            }
+          </div>
+        </header>
+
+        <div class="profile-details">
+          <div class="detail-card">
+            <div class="detail-label">Founded</div>
+            <div class="detail-value">{{ t.originalJoinYear }}</div>
+          </div>
+          <div class="detail-card">
+            <div class="detail-label">Stanley Cups</div>
+            <div class="detail-value">{{ t.stanleyCups.total }}</div>
+          </div>
+          @if (t.season) {
+            <div class="detail-card">
+              <div class="detail-label">Season</div>
+              <div class="detail-value">{{ t.season }}</div>
+            </div>
+          }
+        </div>
+
+        @if (t.franchiseHistory.length > 0) {
+          <section class="section">
+            <h2 class="section-title">Franchise History</h2>
+            @for (fh of t.franchiseHistory; track fh.yearStart) {
+              <div class="fh-row">{{ fh.city }} {{ fh.name }} ({{ fh.yearStart }}–{{ fh.yearEnd }})</div>
+            }
+          </section>
+        }
+
+        <section class="section">
+          <h2 class="section-title">Roster ({{ t.roster.length }})</h2>
+          @if (t.roster.length === 0) {
+            <div class="state-msg">No roster data available.</div>
+          } @else {
+            <div class="table-scroll">
+              <table class="roster-table">
+                <thead>
+                  <tr>
+                    <th class="col-num">#</th>
+                    <th class="col-left">Name</th>
+                    <th>S/C</th>
+                    <th>Born</th>
+                    <th>Birthplace</th>
+                    <th>Draft</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (p of t.roster; track p.playerId; let i = $index) {
+                    <tr [class.row-alt]="i % 2 === 1" [class.row-ebug]="p.isEbug">
+                      <td class="col-num">{{ p.jerseyNumber ?? '—' }}</td>
+                      <td class="col-left col-name">
+                        {{ p.firstName }} {{ p.lastName }}
+                        @if (p.isEbug) { <span class="ebug-tag">EBUG</span> }
+                      </td>
+                      <td>{{ p.shootsCatches }}</td>
+                      <td>{{ formatAge(p.dateOfBirth) }}</td>
+                      <td>{{ p.birthCity }}, {{ p.birthCountry }}</td>
+                      <td>{{ p.draftYear ?? 'UDFA' }}</td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          }
+        </section>
+
+        <a [routerLink]="['/', leagueId(), 'teams']" class="back-link">&larr; All Teams</a>
+      }
+    </div>
+  `,
+  styles: [`
+    .profile-page { max-width: 1000px; margin: 0 auto; padding: 28px 20px 48px; font-family: var(--font-primary); }
+
+    .profile-header { display: flex; align-items: center; gap: 20px; margin-bottom: 24px; }
+    .profile-logo { width: 72px; height: 72px; object-fit: contain; }
+    .profile-title { font-size: 1.3rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-primary); margin: 0; }
+    .profile-meta { font-size: 0.78rem; color: var(--text-muted); margin-top: 2px; }
+    .profile-record { font-size: 0.82rem; color: var(--text-secondary); margin-top: 4px; font-variant-numeric: tabular-nums; }
+
+    .profile-details { display: flex; gap: 12px; margin-bottom: 28px; }
+    .detail-card { background: var(--bg-card); border: 1px solid var(--border-default); border-radius: 4px; padding: 12px 18px; }
+    .detail-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+    .detail-value { font-size: 1.1rem; font-weight: 700; color: var(--text-primary); }
+
+    .section { margin-bottom: 28px; }
+    .section-title { font-size: 0.92rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-primary); margin: 0 0 12px; padding-bottom: 6px; border-bottom: 2px solid var(--border-strong); }
+    .fh-row { font-size: 0.82rem; color: var(--text-secondary); padding: 4px 0; }
+
+    .table-scroll { overflow-x: auto; }
+    .roster-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+    .roster-table th { padding: 8px; text-align: right; font: 700 0.68rem var(--font-primary); text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); border-bottom: 2px solid var(--border-strong); white-space: nowrap; }
+    .roster-table th.col-left { text-align: left; }
+    .roster-table th.col-num { width: 40px; text-align: center; }
+    .roster-table td { padding: 6px 8px; text-align: right; border-bottom: 1px solid var(--border-default); white-space: nowrap; color: var(--text-primary); }
+    .roster-table td.col-left { text-align: left; }
+    .roster-table td.col-num { text-align: center; color: var(--text-muted); font-weight: 700; }
+    .roster-table td.col-name { font-weight: 700; }
+    .roster-table tr.row-alt td { background: var(--bg-row-alt); }
+    .roster-table tr.row-ebug td { opacity: 0.6; }
+    .ebug-tag { font-size: 0.6rem; background: var(--border-default); color: var(--text-muted); padding: 1px 4px; border-radius: 2px; margin-left: 4px; vertical-align: middle; }
+
+    .back-link { font-size: 0.82rem; color: var(--color-link); }
+    .back-link:hover { color: var(--color-link-hover); }
+
+    .state-msg { color: var(--text-muted); text-align: center; padding: 48px 0; font-size: 14px; }
+    .state-error { color: #c44; }
+  `]
+})
+export class TeamProfilePage implements OnInit {
+  private route = inject(ActivatedRoute);
+  private api = inject(TeamsApiService);
+  private destroyRef = inject(DestroyRef);
+
+  leagueId = signal(DEFAULT_LEAGUE_ID);
+  team = signal<TeamProfile | null>(null);
+  loading = signal(true);
+  errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      this.leagueId.set(params.get('leagueId') ?? DEFAULT_LEAGUE_ID);
+      const teamId = Number(params.get('teamId'));
+      if (teamId) this.loadTeam(teamId);
+    });
+  }
+
+  private loadTeam(teamId: number): void {
+    this.loading.set(true);
+    this.api.getTeamProfile(teamId).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: t => { this.team.set(t); this.loading.set(false); },
+      error: () => { this.loading.set(false); this.errorMessage.set('Unable to load team.'); }
+    });
+  }
+
+  formatAge(dob: string): string {
+    const birth = new Date(dob);
+    const now = new Date();
+    let age = now.getFullYear() - birth.getFullYear();
+    if (now.getMonth() < birth.getMonth() || (now.getMonth() === birth.getMonth() && now.getDate() < birth.getDate())) age--;
+    return age.toString();
+  }
+
+  ordinal(n: number): string {
+    const s = ['th', 'st', 'nd', 'rd'];
+    const v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+  }
+}

--- a/frontend/src/app/components/teams/teams-index/teams-index.ts
+++ b/frontend/src/app/components/teams/teams-index/teams-index.ts
@@ -1,7 +1,97 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal, OnInit, ChangeDetectionStrategy, DestroyRef } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TeamsApiService, TeamListItem } from '../../../services/teams-api.service';
+import { DEFAULT_LEAGUE_ID } from '../../../constants';
 
 @Component({
   selector: 'app-teams-index',
-  template: `<p>Teams Index — placeholder</p>`
+  imports: [RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="teams-page">
+      <h1 class="page-title">NHL Teams</h1>
+
+      @if (errorMessage()) {
+        <div class="state-msg state-error">{{ errorMessage() }}</div>
+      } @else if (loading()) {
+        <div class="state-msg">Loading teams...</div>
+      } @else {
+        <div class="teams-grid">
+          @for (team of teams(); track team.id) {
+            <a class="team-card" [routerLink]="['/', leagueId(), 'teams', team.id]">
+              @if (team.logoUrl) {
+                <img [src]="team.logoUrl" [alt]="team.abbreviation" class="team-logo" />
+              } @else {
+                <div class="team-logo-placeholder">{{ team.abbreviation }}</div>
+              }
+              <div class="team-info">
+                <div class="team-name">{{ team.locationName }} {{ team.name }}</div>
+                <div class="team-meta">
+                  {{ team.abbreviation }}
+                  @if (team.division) {
+                    &middot; {{ team.division }}
+                  }
+                </div>
+                @if (team.record) {
+                  <div class="team-record">{{ team.record }} &middot; {{ team.points }} pts</div>
+                }
+              </div>
+            </a>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .teams-page { max-width: 1200px; margin: 0 auto; padding: 28px 20px 48px; font-family: var(--font-primary); }
+    .page-title { font-size: 1.2rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-primary); margin: 0 0 24px; }
+
+    .teams-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+
+    .team-card { display: flex; align-items: center; gap: 12px; padding: 14px 16px; background: var(--bg-card); border: 1px solid var(--border-default); border-radius: 4px; text-decoration: none; color: var(--text-primary); }
+    .team-card:hover { border-color: var(--border-strong); background: var(--bg-row-alt); }
+
+    .team-logo { width: 40px; height: 40px; object-fit: contain; flex-shrink: 0; }
+    .team-logo-placeholder { width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; font: 700 0.72rem var(--font-primary); border: 1px solid var(--border-default); border-radius: 4px; color: var(--text-muted); flex-shrink: 0; }
+
+    .team-info { min-width: 0; }
+    .team-name { font-size: 0.82rem; font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .team-meta { font-size: 0.68rem; color: var(--text-muted); }
+    .team-record { font-size: 0.72rem; color: var(--text-secondary); margin-top: 2px; font-variant-numeric: tabular-nums; }
+
+    .state-msg { color: var(--text-muted); text-align: center; padding: 48px 0; font-size: 14px; }
+    .state-error { color: #c44; }
+
+    @media (max-width: 1024px) { .teams-grid { grid-template-columns: repeat(3, 1fr); } }
+    @media (max-width: 768px) { .teams-grid { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 480px) { .teams-grid { grid-template-columns: 1fr; } }
+  `]
 })
-export class TeamsIndex {}
+export class TeamsIndex implements OnInit {
+  private route = inject(ActivatedRoute);
+  private api = inject(TeamsApiService);
+  private destroyRef = inject(DestroyRef);
+
+  leagueId = signal(DEFAULT_LEAGUE_ID);
+  teams = signal<TeamListItem[]>([]);
+  loading = signal(true);
+  errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      this.leagueId.set(params.get('leagueId') ?? DEFAULT_LEAGUE_ID);
+      this.loadTeams();
+    });
+  }
+
+  private loadTeams(): void {
+    this.loading.set(true);
+    this.api.getTeams(this.leagueId()).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: res => { this.teams.set(res.teams); this.loading.set(false); },
+      error: () => { this.loading.set(false); this.errorMessage.set('Unable to load teams.'); }
+    });
+  }
+}

--- a/frontend/src/app/services/teams-api.service.ts
+++ b/frontend/src/app/services/teams-api.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../constants';
+
+export interface TeamsListResponse {
+  teams: TeamListItem[];
+}
+
+export interface TeamListItem {
+  id: number;
+  locationName: string;
+  name: string;
+  abbreviation: string;
+  logoUrl: string | null;
+  primaryColor: string;
+  division: string | null;
+  conference: string | null;
+  record: string | null;
+  points: number | null;
+  pointsPct: number | null;
+}
+
+export interface TeamProfile {
+  id: number;
+  locationName: string;
+  name: string;
+  abbreviation: string;
+  logoUrl: string | null;
+  primaryColor: string;
+  division: string | null;
+  conference: string | null;
+  currentSeasonRecord: { wins: number; losses: number; overtimeLosses: number } | null;
+  points: number | null;
+  pointsPct: number | null;
+  leagueRank: number | null;
+  divisionRank: number | null;
+  joinedSeasonYear: number;
+  originalJoinYear: number;
+  stanleyCups: { total: number; since1973: number; since2006: number };
+  franchiseHistory: { city: string; name: string; yearStart: number; yearEnd: number }[];
+  season: string | null;
+  roster: RosterPlayer[];
+  dataAsOf: string;
+}
+
+export interface RosterPlayer {
+  playerId: number;
+  firstName: string;
+  lastName: string;
+  jerseyNumber: number | null;
+  shootsCatches: string;
+  birthCity: string;
+  birthCountry: string;
+  dateOfBirth: string;
+  draftYear: number | null;
+  isEbug: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TeamsApiService {
+  private http = inject(HttpClient);
+
+  getTeams(leagueId: string): Observable<TeamsListResponse> {
+    return this.http.get<TeamsListResponse>(`${API_BASE_URL}/api/leagues/${leagueId}/teams`);
+  }
+
+  getTeamProfile(teamId: number): Observable<TeamProfile> {
+    return this.http.get<TeamProfile>(`${API_BASE_URL}/api/teams/${teamId}`);
+  }
+}


### PR DESCRIPTION
TeamsController with two endpoints: GET /api/leagues/{id}/teams (all teams with standings summary, cached 24h) and GET /api/teams/{id} (profile with record, Stanley Cups, franchise history, full roster). Frontend: teams index as a responsive 4-column card grid with logos, records, and division info; team profile page with header, detail cards, and sortable roster table. New route :leagueId/teams/:teamId. Banner search now navigates directly to team profile on click.