### PR TITLE
Fix CS0853: remove named args from EF expression tree Select

### DIFF
--- a/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
@@ -74,16 +74,16 @@ public class TeamsQueryService(HockeyHubDbContext db, RedisCacheService cache)
                 .Where(p => p.CurrentTeamId == teamId && p.IsActive)
                 .OrderBy(p => p.LastName).ThenBy(p => p.FirstName)
                 .Select(p => new RosterPlayerDto(
-                    PlayerId: p.Id,
-                    FirstName: p.FirstName,
-                    LastName: p.LastName,
-                    JerseyNumber: p.JerseyNumber,
-                    ShootsCatches: p.ShootsCatches,
-                    BirthCity: p.BirthCity,
-                    BirthCountry: p.BirthCountry,
-                    DateOfBirth: p.DateOfBirth,
-                    DraftYear: p.DraftYear,
-                    IsEbug: p.IsEbug
+                    p.Id,
+                    p.FirstName,
+                    p.LastName,
+                    p.JerseyNumber,
+                    p.ShootsCatches,
+                    p.BirthCity,
+                    p.BirthCountry,
+                    p.DateOfBirth,
+                    p.DraftYear,
+                    p.IsEbug
                 ))
                 .ToListAsync(ct);
 


### PR DESCRIPTION
Named argument syntax in record constructors inside LINQ Select is not supported in expression trees (CS0853). Passes in Debug but fails in Release builds (Docker CI). Switched to positional arguments.