### PR TITLE
Add Trades: entities, sync job, API endpoint, frontend page

### DIFF
--- a/backend/src/HockeyHub.Api/Controllers/TradesController.cs
+++ b/backend/src/HockeyHub.Api/Controllers/TradesController.cs
@@ -1,0 +1,36 @@
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Queries;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class TradesController(TradesQueryService tradesQuery, HockeyHubDbContext db) : ControllerBase
+{
+    [HttpGet("leagues/{leagueId}/trades")]
+    public async Task<IActionResult> GetTrades(
+        string leagueId,
+        [FromQuery] int? team = null,
+        CancellationToken ct = default)
+    {
+        var id = await ResolveLeagueId(leagueId, ct);
+        if (id is null) return NotFound("League not found");
+
+        var result = await tradesQuery.GetTradesAsync(id.Value, team, ct);
+        if (result is null) return NotFound("No current season found for league");
+
+        return Ok(result);
+    }
+
+    private async Task<int?> ResolveLeagueId(string leagueId, CancellationToken ct)
+    {
+        if (int.TryParse(leagueId, out var numericId))
+            return numericId;
+
+        var league = await db.Leagues
+            .FirstOrDefaultAsync(l => l.Abbreviation.ToLower() == leagueId.ToLower(), ct);
+        return league?.Id;
+    }
+}

--- a/backend/src/HockeyHub.Api/Program.cs
+++ b/backend/src/HockeyHub.Api/Program.cs
@@ -63,6 +63,8 @@ builder.Services.AddScoped<StandingsQueryService>();
 builder.Services.AddScoped<ScheduleQueryService>();
 builder.Services.AddScoped<TeamsQueryService>();
 builder.Services.AddScoped<GameHubQueryService>();
+builder.Services.AddScoped<TradesQueryService>();
+builder.Services.AddScoped<TradeSyncJob>();
 builder.Services.AddScoped<ScoresSyncJob>();
 builder.Services.AddScoped<StandingsSyncJob>();
 builder.Services.AddScoped<ScheduleSyncJob>();
@@ -156,6 +158,11 @@ app.Services.GetRequiredService<IRecurringJobManager>().AddOrUpdate<ScheduleSync
     "schedule-sync",
     job => job.SyncAsync(CancellationToken.None),
     "0 6 * * *"); // Daily at 6 AM UTC
+
+app.Services.GetRequiredService<IRecurringJobManager>().AddOrUpdate<TradeSyncJob>(
+    "trade-sync",
+    job => job.SyncAsync(CancellationToken.None),
+    "0 7 * * *"); // Daily at 7 AM UTC
 
 // Data seed command: dotnet run -- --seed [--current-only]
 if (args.Contains("--seed"))

--- a/backend/src/HockeyHub.Core/Models/Entities/Trade.cs
+++ b/backend/src/HockeyHub.Core/Models/Entities/Trade.cs
@@ -1,0 +1,13 @@
+namespace HockeyHub.Core.Models.Entities;
+
+public class Trade
+{
+    public int Id { get; set; }
+    public int SeasonId { get; set; }
+    public DateOnly TradeDate { get; set; }
+    public string? Description { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
+
+    public Season Season { get; set; } = null!;
+    public ICollection<TradeAsset> Assets { get; set; } = [];
+}

--- a/backend/src/HockeyHub.Core/Models/Entities/TradeAsset.cs
+++ b/backend/src/HockeyHub.Core/Models/Entities/TradeAsset.cs
@@ -1,0 +1,18 @@
+namespace HockeyHub.Core.Models.Entities;
+
+public class TradeAsset
+{
+    public int Id { get; set; }
+    public int TradeId { get; set; }
+    public int TeamId { get; set; }
+    public required string Direction { get; set; }
+    public required string AssetType { get; set; }
+    public int? PlayerId { get; set; }
+    public string? PlayerName { get; set; }
+    public int? DraftPickYear { get; set; }
+    public int? DraftPickRound { get; set; }
+    public string? Description { get; set; }
+
+    public Trade Trade { get; set; } = null!;
+    public Team Team { get; set; } = null!;
+}

--- a/backend/src/HockeyHub.Data/Data/HockeyHubDbContext.cs
+++ b/backend/src/HockeyHub.Data/Data/HockeyHubDbContext.cs
@@ -16,6 +16,8 @@ public class HockeyHubDbContext(DbContextOptions<HockeyHubDbContext> options) : 
     public DbSet<Game> Games => Set<Game>();
     public DbSet<GamePeriodScore> GamePeriodScores => Set<GamePeriodScore>();
     public DbSet<StandingsSnapshot> StandingsSnapshots => Set<StandingsSnapshot>();
+    public DbSet<Trade> Trades => Set<Trade>();
+    public DbSet<TradeAsset> TradeAssets => Set<TradeAsset>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -157,6 +159,30 @@ public class HockeyHubDbContext(DbContextOptions<HockeyHubDbContext> options) : 
             entity.HasOne(e => e.Season)
                 .WithMany()
                 .HasForeignKey(e => e.SeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<Trade>(entity =>
+        {
+            entity.HasIndex(e => new { e.SeasonId, e.TradeDate });
+
+            entity.HasOne(e => e.Season)
+                .WithMany()
+                .HasForeignKey(e => e.SeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<TradeAsset>(entity =>
+        {
+            entity.HasIndex(e => e.TradeId);
+
+            entity.HasOne(e => e.Trade)
+                .WithMany(t => t.Assets)
+                .HasForeignKey(e => e.TradeId);
+
+            entity.HasOne(e => e.Team)
+                .WithMany()
+                .HasForeignKey(e => e.TeamId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
     }

--- a/backend/src/HockeyHub.Data/Migrations/20260412034600_AddTrades.Designer.cs
+++ b/backend/src/HockeyHub.Data/Migrations/20260412034600_AddTrades.Designer.cs
@@ -4,6 +4,7 @@ using HockeyHub.Data.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HockeyHub.Data.Migrations
 {
     [DbContext(typeof(HockeyHubDbContext))]
-    partial class HockeyHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412034600_AddTrades")]
+    partial class AddTrades
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/HockeyHub.Data/Migrations/20260412034600_AddTrades.cs
+++ b/backend/src/HockeyHub.Data/Migrations/20260412034600_AddTrades.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HockeyHub.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrades : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Trades",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SeasonId = table.Column<int>(type: "int", nullable: false),
+                    TradeDate = table.Column<DateOnly>(type: "date", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LastUpdated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Trades", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Trades_Seasons_SeasonId",
+                        column: x => x.SeasonId,
+                        principalTable: "Seasons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TradeAssets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    TradeId = table.Column<int>(type: "int", nullable: false),
+                    TeamId = table.Column<int>(type: "int", nullable: false),
+                    Direction = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AssetType = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PlayerId = table.Column<int>(type: "int", nullable: true),
+                    PlayerName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    DraftPickYear = table.Column<int>(type: "int", nullable: true),
+                    DraftPickRound = table.Column<int>(type: "int", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TradeAssets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TradeAssets_Teams_TeamId",
+                        column: x => x.TeamId,
+                        principalTable: "Teams",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TradeAssets_Trades_TradeId",
+                        column: x => x.TradeId,
+                        principalTable: "Trades",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TradeAssets_TeamId",
+                table: "TradeAssets",
+                column: "TeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TradeAssets_TradeId",
+                table: "TradeAssets",
+                column: "TradeId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Trades_SeasonId_TradeDate",
+                table: "Trades",
+                columns: new[] { "SeasonId", "TradeDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TradeAssets");
+
+            migrationBuilder.DropTable(
+                name: "Trades");
+        }
+    }
+}

--- a/backend/src/HockeyHub.Data/Services/Queries/TradesQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/TradesQueryService.cs
@@ -1,0 +1,99 @@
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Cache;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Data.Services.Queries;
+
+public class TradesQueryService(HockeyHubDbContext db, RedisCacheService cache)
+{
+    public async Task<TradesListResponse?> GetTradesAsync(
+        int leagueId, int? teamId, CancellationToken ct = default)
+    {
+        var season = await db.Seasons
+            .Where(s => s.LeagueId == leagueId && s.IsCurrent)
+            .FirstOrDefaultAsync(ct);
+        if (season is null) return null;
+
+        var cacheKey = $"trades:{leagueId}:{teamId?.ToString() ?? "all"}";
+
+        var trades = await cache.GetOrSetAsync(cacheKey, async _ =>
+        {
+            var query = db.Trades
+                .Where(t => t.SeasonId == season.Id)
+                .Include(t => t.Assets).ThenInclude(a => a.Team)
+                .OrderByDescending(t => t.TradeDate)
+                .AsQueryable();
+
+            if (teamId.HasValue)
+                query = query.Where(t => t.Assets.Any(a => a.TeamId == teamId.Value));
+
+            var tradeEntities = await query.ToListAsync(ct);
+
+            return tradeEntities.Select(t =>
+            {
+                var sides = t.Assets
+                    .GroupBy(a => a.TeamId)
+                    .Select(g =>
+                    {
+                        var team = g.First().Team;
+                        return new TradeSideDto(
+                            TeamId: team.Id,
+                            TeamAbbreviation: team.Abbreviation,
+                            TeamName: $"{team.LocationName} {team.Name}",
+                            TeamLogoUrl: team.LogoUrl,
+                            Acquired: g.Where(a => a.Direction == "Acquired")
+                                .Select(a => new TradeAssetDto(a.AssetType, a.PlayerId, a.PlayerName, a.Description))
+                                .ToList(),
+                            Traded: g.Where(a => a.Direction == "Traded")
+                                .Select(a => new TradeAssetDto(a.AssetType, a.PlayerId, a.PlayerName, a.Description))
+                                .ToList()
+                        );
+                    }).ToList();
+
+                return new TradeDto(
+                    t.Id,
+                    t.TradeDate.ToString("yyyy-MM-dd"),
+                    t.TradeDate.ToString("MM/dd/yyyy"),
+                    t.Description,
+                    sides
+                );
+            }).ToList();
+        }, TimeSpan.FromHours(3), ct);
+
+        return new TradesListResponse(
+            Season: season.Label,
+            DataAsOf: DateTimeOffset.UtcNow,
+            Trades: trades ?? []
+        );
+    }
+}
+
+public record TradesListResponse(
+    string Season,
+    DateTimeOffset DataAsOf,
+    IReadOnlyList<TradeDto> Trades
+);
+
+public record TradeDto(
+    int Id,
+    string TradeDate,
+    string TradeDateDisplay,
+    string? Description,
+    IReadOnlyList<TradeSideDto> Sides
+);
+
+public record TradeSideDto(
+    int TeamId,
+    string TeamAbbreviation,
+    string TeamName,
+    string? TeamLogoUrl,
+    IReadOnlyList<TradeAssetDto> Acquired,
+    IReadOnlyList<TradeAssetDto> Traded
+);
+
+public record TradeAssetDto(
+    string AssetType,
+    int? PlayerId,
+    string? PlayerName,
+    string? Description
+);

--- a/backend/src/HockeyHub.Data/Services/Sync/TradeSyncJob.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/TradeSyncJob.cs
@@ -1,0 +1,96 @@
+using HockeyHub.Core.Models.Entities;
+using HockeyHub.Core.Providers;
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Cache;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HockeyHub.Data.Services.Sync;
+
+public class TradeSyncJob(
+    HockeyHubDbContext db,
+    INhlDataProvider nhlProvider,
+    RedisCacheService cache,
+    ILogger<TradeSyncJob> logger)
+{
+    public async Task SyncAsync(CancellationToken ct = default)
+    {
+        logger.LogInformation("Syncing trades");
+
+        var league = await db.Leagues.FirstOrDefaultAsync(l => l.Abbreviation == "NHL", ct);
+        if (league is null) { logger.LogError("NHL league not found — has DataSeed been run?"); return; }
+
+        var season = await db.Seasons
+            .FirstOrDefaultAsync(s => s.LeagueId == league.Id && s.IsCurrent, ct);
+        if (season is null) { logger.LogError("No current season found for NHL"); return; }
+
+        var tradeData = await nhlProvider.GetTradesAsync("now", ct);
+        if (tradeData.Count == 0)
+        {
+            logger.LogInformation("NHL API returned no trades");
+            return;
+        }
+
+        var teams = await db.Teams
+            .Where(t => t.LeagueId == league.Id)
+            .ToDictionaryAsync(t => t.Abbreviation, ct);
+
+        // Simple approach: remove existing trades for season and re-insert.
+        // Trade data is small (~50-100 per season) and rarely changes retroactively.
+        var existingTrades = await db.Trades
+            .Where(t => t.SeasonId == season.Id)
+            .Include(t => t.Assets)
+            .ToListAsync(ct);
+
+        if (existingTrades.Count > 0)
+        {
+            db.TradeAssets.RemoveRange(existingTrades.SelectMany(t => t.Assets));
+            db.Trades.RemoveRange(existingTrades);
+            await db.SaveChangesAsync(ct);
+        }
+
+        var inserted = 0;
+        foreach (var td in tradeData)
+        {
+            var trade = new Trade
+            {
+                SeasonId = season.Id,
+                TradeDate = td.TradeDate,
+                Description = td.Description,
+                LastUpdated = DateTimeOffset.UtcNow
+            };
+
+            foreach (var side in td.Sides)
+            {
+                if (!teams.TryGetValue(side.TeamAbbreviation, out var team))
+                {
+                    logger.LogWarning("Unknown team in trade: {Abbrev}", side.TeamAbbreviation);
+                    continue;
+                }
+
+                foreach (var asset in side.Assets)
+                {
+                    trade.Assets.Add(new TradeAsset
+                    {
+                        TeamId = team.Id,
+                        Direction = side.Direction,
+                        AssetType = asset.AssetType,
+                        PlayerId = asset.PlayerId,
+                        PlayerName = asset.PlayerName,
+                        DraftPickYear = asset.DraftPickYear,
+                        DraftPickRound = asset.DraftPickRound,
+                        Description = asset.Description
+                    });
+                }
+            }
+
+            db.Trades.Add(trade);
+            inserted++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        await cache.RemoveAsync($"trades:{league.Id}", ct);
+
+        logger.LogInformation("Synced {Count} trades for season {Season}", inserted, season.Label);
+    }
+}

--- a/frontend/src/app/components/trades/trades-list/trades-list.ts
+++ b/frontend/src/app/components/trades/trades-list/trades-list.ts
@@ -1,7 +1,128 @@
-import { Component } from '@angular/core';
+import {
+  Component, inject, signal, OnInit,
+  ChangeDetectionStrategy, DestroyRef,
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TradesApiService, TradeItem } from '../../../services/trades-api.service';
+import { DEFAULT_LEAGUE_ID } from '../../../constants';
 
 @Component({
   selector: 'app-trades-list',
-  template: `<p>Trades List — placeholder</p>`
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="trades-page">
+      <h1 class="page-title">{{ data()?.season ?? '...' }} NHL Trades</h1>
+      <p class="page-subtitle">
+        @if (data()) { {{ data()!.trades.length }} trades this season } @else { &nbsp; }
+      </p>
+
+      @if (errorMessage()) {
+        <div class="state-msg state-error">{{ errorMessage() }}</div>
+      } @else if (loading()) {
+        <div class="state-msg">Loading trades...</div>
+      } @else if (trades().length === 0) {
+        <div class="state-msg">No trades found.</div>
+      } @else {
+        @for (trade of trades(); track trade.id) {
+          <div class="trade-card">
+            <div class="trade-date">{{ trade.tradeDateDisplay }}</div>
+            <div class="trade-sides">
+              @for (side of trade.sides; track side.teamId) {
+                <div class="trade-side">
+                  <div class="side-header">
+                    @if (side.teamLogoUrl) {
+                      <img [src]="side.teamLogoUrl" [alt]="side.teamAbbreviation" class="side-logo" />
+                    }
+                    <span class="side-team">{{ side.teamAbbreviation }}</span>
+                  </div>
+                  @if (side.acquired.length > 0) {
+                    <div class="asset-group">
+                      <span class="asset-label">Acquired:</span>
+                      @for (a of side.acquired; track $index) {
+                        <div class="asset">{{ assetDisplay(a) }}</div>
+                      }
+                    </div>
+                  }
+                  @if (side.traded.length > 0) {
+                    <div class="asset-group">
+                      <span class="asset-label">Traded:</span>
+                      @for (a of side.traded; track $index) {
+                        <div class="asset">{{ assetDisplay(a) }}</div>
+                      }
+                    </div>
+                  }
+                </div>
+              }
+            </div>
+            @if (trade.description) {
+              <div class="trade-desc">{{ trade.description }}</div>
+            }
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [`
+    .trades-page { max-width: 900px; margin: 0 auto; padding: 28px 20px 48px; font-family: var(--font-primary); }
+    .page-title { font-size: 1.2rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-primary); margin: 0 0 4px; }
+    .page-subtitle { font-size: 0.78rem; color: var(--text-muted); margin: 0 0 24px; }
+
+    .trade-card { background: var(--bg-card); border: 1px solid var(--border-default); border-radius: 4px; padding: 16px; margin-bottom: 12px; }
+    .trade-date { font: 700 0.76rem var(--font-primary); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 10px; }
+
+    .trade-sides { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .side-header { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+    .side-logo { width: 28px; height: 28px; object-fit: contain; }
+    .side-team { font: 700 0.88rem var(--font-primary); color: var(--text-primary); }
+
+    .asset-group { margin-bottom: 6px; }
+    .asset-label { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-muted); }
+    .asset { font-size: 0.78rem; color: var(--text-secondary); padding: 2px 0; }
+
+    .trade-desc { font-size: 0.74rem; color: var(--text-muted); margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--border-default); line-height: 1.5; }
+
+    .state-msg { color: var(--text-muted); text-align: center; padding: 48px 0; font-size: 14px; }
+    .state-error { color: #c44; }
+
+    @media (max-width: 600px) { .trade-sides { grid-template-columns: 1fr; } }
+  `]
 })
-export class TradesList {}
+export class TradesList implements OnInit {
+  private route = inject(ActivatedRoute);
+  private api = inject(TradesApiService);
+  private destroyRef = inject(DestroyRef);
+
+  leagueId = signal(DEFAULT_LEAGUE_ID);
+  data = signal<{ season: string; trades: TradeItem[] } | null>(null);
+  trades = signal<TradeItem[]>([]);
+  loading = signal(true);
+  errorMessage = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      this.leagueId.set(params.get('leagueId') ?? DEFAULT_LEAGUE_ID);
+      this.loadTrades();
+    });
+  }
+
+  private loadTrades(): void {
+    this.loading.set(true);
+    this.api.getTrades(this.leagueId()).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: res => {
+        this.data.set(res);
+        this.trades.set(res.trades);
+        this.loading.set(false);
+      },
+      error: () => { this.loading.set(false); this.errorMessage.set('Unable to load trades.'); }
+    });
+  }
+
+  assetDisplay(a: { assetType: string; playerName: string | null; description: string | null }): string {
+    if (a.assetType === 'Player' && a.playerName) return a.playerName;
+    if (a.description) return a.description;
+    return a.assetType;
+  }
+}

--- a/frontend/src/app/services/trades-api.service.ts
+++ b/frontend/src/app/services/trades-api.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../constants';
+
+export interface TradesListResponse {
+  season: string;
+  dataAsOf: string;
+  trades: TradeItem[];
+}
+
+export interface TradeItem {
+  id: number;
+  tradeDate: string;
+  tradeDateDisplay: string;
+  description: string | null;
+  sides: TradeSide[];
+}
+
+export interface TradeSide {
+  teamId: number;
+  teamAbbreviation: string;
+  teamName: string;
+  teamLogoUrl: string | null;
+  acquired: TradeAsset[];
+  traded: TradeAsset[];
+}
+
+export interface TradeAsset {
+  assetType: string;
+  playerId: number | null;
+  playerName: string | null;
+  description: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TradesApiService {
+  private http = inject(HttpClient);
+
+  getTrades(leagueId: string, teamId?: number): Observable<TradesListResponse> {
+    const params: Record<string, string | number> = {};
+    if (teamId != null) params['team'] = teamId;
+    return this.http.get<TradesListResponse>(
+      `${API_BASE_URL}/api/leagues/${leagueId}/trades`,
+      { params }
+    );
+  }
+}


### PR DESCRIPTION
Trade + TradeAsset entities (simplified — TradeSide flattened into TradeAsset with Direction + TeamId). TradeSyncJob runs daily at 7 AM UTC via Hangfire, calling GetTradesAsync and re-inserting for the current season. TradesController exposes GET /api/leagues/{id}/trades with optional team filter. Frontend replaces placeholder with chronological trade cards showing each side's acquired/traded assets with team logos.