### PR TITLE
Sync docs: teams, game hub, trades done — 56% complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-11
 backend/
 ├── src/
 │   ├── HockeyHub.Core/             # Entities + interfaces (no dependencies)
-│   │   ├── Models/Entities/         # League, Team, Season, Arena, Player, Personnel, FranchiseHistory, Game, GamePeriodScore, StandingsSnapshot
+│   │   ├── Models/Entities/         # League, Team, Season, Arena, Player, Personnel, FranchiseHistory, Game, GamePeriodScore, StandingsSnapshot, Trade, TradeAsset
 │   │   ├── Providers/               # INhlDataProvider interface + DTOs, IScoreBroadcaster
 │   │   └── NhlDateHelper.cs         # Shared NHL game day boundary logic (3 AM ET cutoff, DST-aware)
 │   ├── HockeyHub.Data/             # Data access (depends on Core)
@@ -20,10 +20,10 @@ backend/
 │   │   ├── Providers/NhlWebApiProvider.cs
 │   │   └── Services/
 │   │       ├── Cache/               # Redis cache service
-│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync jobs
-│   │       └── Queries/             # ScoresQueryService, StandingsQueryService, ScheduleQueryService
+│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync, TradeSync jobs
+│   │       └── Queries/             # Scores, Standings, Schedule, Teams, GameHub, Trades query services
 │   └── HockeyHub.Api/              # HTTP host (depends on Data + Core)
-│       ├── Controllers/             # ScoresController (5), StandingsController, ScheduleController, SearchController, HealthController
+│       ├── Controllers/             # Scores (5), Standings, Schedule, Teams (2), GameHub, Trades, Search, Health
 │       ├── Hubs/                    # GameHub, SignalRScoreBroadcaster
 │       ├── Middleware/              # Error handling, DataAsOf wrapper
 │       ├── Program.cs              # App startup + DI wiring
@@ -51,12 +51,15 @@ frontend/
 │   │   ├── scores/                # ScoresPage, ScoreBox, ExpandedScoreBox, PregameMatchup, CalendarPicker
 │   │   ├── standings/             # StandingsPage (4 views: wildcard/division/conference/league)
 │   │   ├── schedule/              # SchedulePage (monthly game list with navigation)
-│   │   └── [stats,...]/           # Placeholder route components (8 remaining)
+│   │   ├── teams/                 # TeamsIndex (card grid) + TeamProfile (roster table)
+│   │   ├── game-hub/              # GameHubPage (team stats, player stats, goals/penalties)
+│   │   ├── trades/                # TradesList (chronological trade cards)
+│   │   └── [stats,...]/           # Placeholder route components (5 remaining)
 │   ├── constants.ts               # Shared constants (league ID, polling intervals, SignalR config, close-game thresholds, getPeriodLabel)
-│   ├── services/                  # ThemeService, SignalRService, ScoresApiService, GameClockService, StandingsApiService, ScheduleApiService, SearchApiService
+│   ├── services/                  # Theme, SignalR, ScoresApi, StandingsApi, ScheduleApi, SearchApi, TeamsApi, GameHubApi, TradesApi, GameClock
 │   ├── directives/                # TooltipDirective
 │   ├── pipes/                     # EraPipe, TimezonePipe
-│   ├── app.routes.ts              # 14 lazy-loaded routes (incl. game-hub/:gameId)
+│   ├── app.routes.ts              # 15 lazy-loaded routes (incl. game-hub/:gameId, teams/:teamId)
 │   └── app.ts                     # Shell: banner + score bar + nav + router-outlet
 ├── src/assets/fonts/              # Courier Prime (WOFF2)
 ├── src/styles/                    # Design tokens (light/dark)
@@ -103,7 +106,7 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - NHL data sourced via `INhlDataProvider` interface (Core) — implemented by `NhlWebApiProvider` (Data), swappable to licensed provider later
 - `IScoreBroadcaster` interface (Core) abstracts SignalR broadcasting — implemented by `SignalRScoreBroadcaster` (Api) to maintain dependency flow
 - SignalR `GameHub` at `/hubs/scores` for live score push, Redis backplane for multi-server
-- Hangfire recurring jobs: `ScoresSyncJob` (every 15s), `StandingsSyncJob` (every 5min), `ScheduleSyncJob` (daily 6 AM UTC), dashboard at `/hangfire`
+- Hangfire recurring jobs: `ScoresSyncJob` (every 15s), `StandingsSyncJob` (every 5min), `ScheduleSyncJob` (daily 6 AM UTC), `TradeSyncJob` (daily 7 AM UTC), dashboard at `/hangfire`
 - Response wrappers: `DataAsOfResponse<T>` and `PaginatedResponse<T>` in Api/Middleware/
 - Connection strings in appsettings.json for local dev (DefaultConnection: SQL Server on port 1433, Redis: `localhost:6379`); deployed environments inject via Key Vault secret refs → Container App env vars (`ConnectionStrings__DefaultConnection`, `ConnectionStrings__Redis`)
 - EF migrations live in HockeyHub.Data; run `dotnet ef` from Api project with `--project ../HockeyHub.Data`
@@ -114,6 +117,9 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - Subscription cleanup uses `takeUntilDestroyed(destroyRef)` — do not use manual `Subscription[]` + `ngOnDestroy` patterns
 
 ## Recent Changes
+- Trades page: Trade + TradeAsset entities (simplified — TradeSide flattened into TradeAsset), `TradeSyncJob` (daily 7 AM UTC Hangfire) calls `GetTradesAsync` to populate trades for current season, `TradesController` exposes `GET /api/leagues/{leagueId}/trades` with optional team filter, frontend shows chronological trade cards with team logos and acquired/traded asset lists
+- Game Hub page: `GameHubController` exposes `GET /api/games/{gameId}/hub` — combined response with period box scores, team stats comparison, game events (goals/penalties), and per-player box scores (skaters + goalies). Sources from DB game record + live NHL API via `GetGameDetailAsync` with Redis cache (10s live, 1h final). Frontend has Team Stats + Player Stats tabs with responsive layout
+- Teams pages: `TeamsController` with `GET /api/leagues/{id}/teams` (list with standings summary, 24h cache) and `GET /api/teams/{id}` (profile with record, Stanley Cups, franchise history, full roster, 1h cache). Frontend: teams index as 4-column card grid, team profile with header/detail cards/roster table. New route `:leagueId/teams/:teamId`. Search navigates directly to team profiles
 - Search: `GET /api/search?q=...&limit=10` queries Players (name) and Teams (location/name/abbreviation) with grouped results; banner search input wired with 300ms debounce and live dropdown showing Teams/Players sections with navigation links
 - Schedule page: `ScheduleSyncJob` (daily 6 AM UTC Hangfire job) calls `GetScheduleAsync` to populate the full season of games into the Games table; `ScheduleQueryService` groups games by month/day with optional month + team filters (6h Redis cache); `ScheduleController` exposes `GET /api/leagues/{leagueId}/schedule`; frontend page with month navigation, day cards showing matchups/times/scores
 - Standings page (US3): Added `GoalDifferential`, `DivisionRank`, `ConferenceRank`, and nullable `WildCardRank` to `StandingsSnapshot` (closes the data-model.md gap) with EF migration `AddStandingsRanks`; `StandingsSyncJob` now computes all four during the sync loop with NHL wild-card rules (top 3 per division qualify, top 2 of remaining per conference get WC1/WC2, rest are eliminated) and busts `standings:*` cache keys after save; new `StandingsQueryService` shapes 4 view modes (wildcard / division / conference / league) with 1h Redis TTL; new `StandingsController` exposes `GET /api/leagues/{leagueId}/standings?view=...` with view validation; frontend placeholder replaced with full responsive page (side-by-side conferences ≥1200px, tabbed below) using OnPush + signals + `takeUntilDestroyed`; sortable column headers with WC1/WC2 labels, dashed cut line, and muted styling for eliminated teams in default sort order
@@ -147,9 +153,9 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - **SQL admin password rotation**: Initial deploy password is in shell history
 
 ### Missing Implementation
-- **Database entities (14 missing)**: PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerSeason, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, Trade, TradeAsset, ImportantDate, RuleBook
-- **API endpoints (17 missing)**: Game Hub (3), Stats (1), Teams (4), Players (2), Salary Cap (5), Trades (2), Free Agents (1), Personnel (1)
-- **Frontend pages (8 placeholders)**: Stats, Players, Teams, Salary Cap, Trades, Free Agents, Personnel, Game Hub — all currently render placeholder text
+- **Database entities (12 missing)**: PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerSeason, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, ImportantDate, RuleBook
+- **API endpoints (12 missing)**: Stats (1), Players (2), Salary Cap (5), Free Agents (1), Personnel (1), Teams roster (1), Teams depth chart (1)
+- **Frontend pages (5 placeholders)**: Stats, Players, Salary Cap, Free Agents, Personnel — all currently render placeholder text
 
 ### Data Quality Bugs in NhlWebApiProvider
 - **`GetStandingsAsync` doesn't populate `PowerPlayPct`, `PenaltyKillPct`, `FaceoffPct`** — they come back as `0.0` / `null` for every team. Surfaced 2026-04-08 during standings smoke test. The standings page renders "0.0" / "—" until the provider extracts those fields from the NHL API response.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Comprehensive hockey league information website starting with NHL — scores, st
 backend/
 ├── src/
 │   ├── HockeyHub.Core/             # Entities + interfaces (no dependencies)
-│   │   ├── Models/Entities/         # EF Core entities (10: League through StandingsSnapshot)
+│   │   ├── Models/Entities/         # EF Core entities (12: League through TradeAsset)
 │   │   └── Providers/               # INhlDataProvider, IScoreBroadcaster + DTOs
 │   ├── HockeyHub.Data/             # Data access layer (depends on Core)
 │   │   ├── Data/                    # DbContext, EF Core migrations
 │   │   ├── Providers/               # NhlWebApiProvider (api-web.nhle.com)
 │   │   └── Services/
 │   │       ├── Cache/               # Redis caching service
-│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync jobs
-│   │       └── Queries/             # ScoresQuery, StandingsQuery, ScheduleQuery services
+│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync, TradeSync jobs
+│   │       └── Queries/             # Scores, Standings, Schedule, Teams, GameHub, Trades query services
 │   └── HockeyHub.Api/              # HTTP host (depends on Data + Core)
-│       ├── Controllers/             # Scores (5), Standings, Schedule, Search, Health controllers
+│       ├── Controllers/             # Scores (5), Standings, Teams (2), GameHub, Schedule, Trades, Search, Health
 │       ├── Hubs/                    # GameHub, SignalRScoreBroadcaster
 │       ├── Middleware/              # Error handling, response wrappers
 │       └── Program.cs              # App startup, DI, Hangfire jobs
@@ -39,11 +39,14 @@ frontend/
 │   │   ├── scores/                  # ScoresPage, ScoreBox, ExpandedScoreBox, PregameMatchup, CalendarPicker
 │   │   ├── standings/               # StandingsPage (4 views, sortable, responsive side-by-side/tabbed)
 │   │   ├── schedule/                # SchedulePage (monthly game list with navigation)
-│   │   └── [8 placeholders]/        # Stats, Teams, Players, Salary Cap, Trades, Free Agents, Personnel, Game Hub
-│   ├── services/                    # Theme, SignalR, ScoresApi, StandingsApi, ScheduleApi, SearchApi, GameClock
+│   │   ├── teams/                   # TeamsIndex (card grid) + TeamProfile (roster table)
+│   │   ├── game-hub/                # GameHubPage (team stats, player stats, goals/penalties)
+│   │   ├── trades/                  # TradesList (chronological trade cards)
+│   │   └── [5 placeholders]/        # Stats, Players, Salary Cap, Free Agents, Personnel
+│   ├── services/                    # Theme, SignalR, ScoresApi, StandingsApi, ScheduleApi, TeamsApi, GameHubApi, TradesApi, SearchApi, GameClock
 │   ├── directives/                  # TooltipDirective
 │   ├── pipes/                       # EraPipe, TimezonePipe
-│   └── app.routes.ts                # 14 lazy-loaded routes (incl. game-hub/:gameId)
+│   └── app.routes.ts                # 15 lazy-loaded routes (incl. game-hub/:gameId, teams/:teamId)
 ├── src/assets/fonts/                # Self-hosted Courier Prime (WOFF2)
 ├── src/styles/                      # Design tokens (light/dark mode)
 └── tests/                           # Frontend tests
@@ -229,6 +232,10 @@ Standalone HTML/CSS mockups for design review, viewable in any browser from `doc
 | GET | `/api/leagues/{id}/scores/{gameId}/pregame` | Pregame matchup (goalies, PP/PK, H2H) |
 | GET | `/api/leagues/{id}/standings?view=wildcard` | Standings in 4 views: wildcard, division, conference, league |
 | GET | `/api/leagues/{id}/schedule?month=&team=` | Season schedule grouped by month/day, optional filters |
+| GET | `/api/leagues/{id}/teams` | All active teams with standings summary |
+| GET | `/api/teams/{teamId}` | Team profile with record, Stanley Cups, roster |
+| GET | `/api/games/{gameId}/hub` | Game Hub: period scores, team stats, events, player stats |
+| GET | `/api/leagues/{id}/trades?team=` | Season trades list, optional team filter |
 | GET | `/api/search?q=...&limit=10` | Cross-entity search (players by name, teams by name/abbreviation) |
 | GET | `/api/health/live` | Liveness probe (always 200) |
 | GET | `/api/health/ready` | Readiness probe (checks DB + Redis) |
@@ -242,4 +249,5 @@ Standalone HTML/CSS mockups for design review, viewable in any browser from `doc
 - **Phase 3 (US1: Scores MVP)**: Complete — Game/GamePeriodScore/StandingsSnapshot entities, ScoresController (5 endpoints), ScoresSyncJob + StandingsSyncJob, live score bar, scores page with 4-column grid, score box, expanded score box, pregame matchup, calendar picker, GameClockService (rAF countdown), tooltip directive
 - **Phase 4 (Standings)**: Complete — StandingsSnapshot extended with GoalDifferential + division/conference/wild card ranks; StandingsController (1 endpoint, 4 views); responsive frontend (side-by-side wide, tabbed narrow); sortable columns with WC cut-line semantics
 - **Phase 5 (Quick Wins)**: Complete — Global search (SearchController + banner dropdown with debounce); Schedule page (ScheduleSyncJob populates full season, ScheduleController with month/team filters, monthly game list frontend)
-- **Remaining**: Game Hub (3 endpoints, 2 entities), Stats (1), Teams (4), Players (2), Salary Cap (5), Trades (2), Free Agents (1), Personnel (1) — 8 placeholder frontend pages
+- **Phase 6 (Teams + Game Hub + Trades)**: Complete — Teams list + profile pages (card grid, roster table); Game Hub page (team stats + player stats tabs, goals/penalties timeline, sources from NHL API with Redis cache); Trades page (Trade + TradeAsset entities, TradeSyncJob daily sync, chronological trade cards with team logos)
+- **Remaining (~56% complete)**: Stats (1 endpoint), Players (2), Salary Cap (5), Free Agents (1), Personnel (1) — 5 placeholder frontend pages, all blocked on missing entities or data sources

--- a/docs/audit-2026-04-05.md
+++ b/docs/audit-2026-04-05.md
@@ -195,35 +195,36 @@ Point-in-time audit covering security, code quality, infrastructure, and spec-vs
 
 ## Spec vs Implementation Gap
 
-### Overall Completion: ~37% (updated 2026-04-11)
+### Overall Completion: ~56% (updated 2026-04-12)
 
 | Category | Spec | Done | Remaining |
 |----------|------|------|-----------|
-| Database Entities | 24 | 10 | 14 |
-| API Endpoints | 27 | 10 | 17 |
-| Frontend Pages | 12 | 4 | 8 |
-| Functional Requirements | 73 | ~25 | ~48 |
+| Database Entities | 24 | 12 | 12 |
+| API Endpoints | 27 | 15 | 12 |
+| Frontend Pages | 12 | 7 | 5 |
+| Functional Requirements | 73 | ~40 | ~33 |
 
-**Since last audit (2026-04-05):** Standings page (1 endpoint, 4 views, responsive frontend), Schedule page (1 endpoint + ScheduleSyncJob for full season, monthly game list), Search (1 endpoint + live banner dropdown). StandingsSnapshot entity extended with GoalDifferential, DivisionRank, ConferenceRank, WildCardRank.
+**Since last audit (2026-04-05):** Standings (1 endpoint, 4 views, responsive), Schedule (1 endpoint + ScheduleSyncJob), Search (1 endpoint + banner dropdown), Teams (2 endpoints — list + profile with roster), Game Hub (1 combined endpoint — team stats + player stats + events, sourced from NHL API with Redis cache), Trades (1 endpoint + Trade/TradeAsset entities + TradeSyncJob). StandingsSnapshot extended with 4 rank columns. SWA navigation fallback fix. 6 new Angular services, 7 new frontend pages replacing placeholders.
 
-### Missing Database Entities (14)
-PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerSeason, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, Trade, TradeAsset, ImportantDate, RuleBook
+### Missing Database Entities (12)
+PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerSeason, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, ImportantDate, RuleBook
 
-### Missing API Endpoints by Feature (17)
+### Missing API Endpoints by Feature (12)
 
 | Feature | Endpoints Needed | Blocking Entities |
 |---------|-----------------|-------------------|
-| Game Hub | 3 (game detail, player stats, rink events) | GameEvent, GamePlayerStat |
 | Stats | 1 | PlayerSeason |
-| Teams | 4 (list, profile, roster, depth chart) | PlayerPosition |
 | Players | 2 (profile, stats) | PlayerSeason, PlayerTeamHistory, PlayerAward |
 | Salary Cap | 5 (overview, team detail, player detail, buyout calc, explained) | Contract, ContractYear |
-| Trades | 2 (list, detail) | Trade, TradeAsset |
 | Free Agents | 1 | Contract |
 | Personnel | 1 | None (Personnel exists, but no data source — NHL API has no staff endpoint, table is empty) |
+| Teams roster | 1 (dedicated roster endpoint, currently embedded in profile) | None |
+| Teams depth chart | 1 | PlayerPosition |
 
-### Frontend Placeholder Pages (8)
-Stats, Players, Teams, Salary Cap, Trades, Free Agents, Personnel, Game Hub — all render `<p>Page — placeholder</p>`
+**Note**: Game Hub currently sources events + player stats from the NHL API at request time (cached). GameEvent + GamePlayerStat entities are specced but not yet created — they'd enable offline historical queries and faster response times.
+
+### Frontend Placeholder Pages (5)
+Stats, Players, Salary Cap, Free Agents, Personnel — all render `<p>Page — placeholder</p>`
 
 ---
 
@@ -233,6 +234,9 @@ Stats, Players, Teams, Salary Cap, Trades, Free Agents, Personnel, Game Hub — 
 - **Standings page** — 4 view modes (wildcard/division/conference/league), responsive layout (side-by-side wide, tabbed narrow), sortable columns, wild card cut-line semantics, 1h Redis cache
 - **Schedule page** — ScheduleSyncJob populates full season from NHL API, monthly game list with navigation, 6h cache
 - **Global search** — banner input with 300ms debounce, live dropdown grouping Players + Teams results
+- **Teams pages** — teams index (4-column card grid with standings), team profile (header, detail cards, full roster table)
+- **Game Hub** — team stats + player stats tabs, period box scores, team comparison, goals/penalties timeline with PPG/SHG/EN tags, skater/goalie stat tables
+- **Trades page** — Trade + TradeAsset entities with daily sync, chronological trade cards with team logos and asset lists
 - **Modern Angular patterns** — OnPush everywhere, signals, takeUntilDestroyed, new control flow
 - **Strict TypeScript** — `strict: true`, no `any` types in codebase
 - **Clean architecture** — Core → Data → Api dependency flow properly enforced


### PR DESCRIPTION
CLAUDE.md: updated project structure (12 entities, 6 query services, 8 controllers), services list, route count, Hangfire jobs (TradeSyncJob), recent changes entries, missing impl counts (12 endpoints, 5 pages). README.md: project tree, API endpoints table (+4), development status through phase 6. Audit doc: completion 37%→56%, 15/27 endpoints, 7/12 pages, updated gap tables and What's Working Well section.