### PR TITLE
Show real data-last-updated timestamps on all pages

### DIFF
--- a/backend/src/HockeyHub.Data/Services/Queries/GameHubQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/GameHubQueryService.cs
@@ -76,7 +76,7 @@ public class GameHubQueryService(
                 e.VideoUrl
             )).ToList() ?? [],
             PlayerStats: BuildPlayerStats(detail),
-            DataAsOf: DateTimeOffset.UtcNow
+            DataAsOf: game.LastUpdated
         );
     }
 

--- a/backend/src/HockeyHub.Data/Services/Queries/ScheduleQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/ScheduleQueryService.cs
@@ -66,9 +66,13 @@ public class ScheduleQueryService(HockeyHubDbContext db, RedisCacheService cache
                 )).ToList();
         }, RedisCacheService.ScheduleTtl, ct);
 
+        var lastUpdated = await db.Games
+            .Where(g => g.SeasonId == season.Id)
+            .MaxAsync(g => (DateTimeOffset?)g.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+
         return new ScheduleResponse(
             Season: season.Label,
-            DataAsOf: DateTimeOffset.UtcNow,
+            DataAsOf: lastUpdated,
             Months: months ?? []
         );
     }

--- a/backend/src/HockeyHub.Data/Services/Queries/ScoresQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/ScoresQueryService.cs
@@ -60,11 +60,15 @@ public class ScoresQueryService(
                 showPreviousDay = true;
         }
 
+        var lastUpdated = await db.Games
+            .Where(g => g.Season.LeagueId == leagueId && g.GameDateLocal == date)
+            .MaxAsync(g => (DateTimeOffset?)g.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+
         return new ScoresResponse(
             Date: date.ToString("yyyy-MM-dd"),
             DateDisplay: date.ToString("MM/dd"),
             ShowPreviousDay: showPreviousDay,
-            DataAsOf: DateTimeOffset.UtcNow,
+            DataAsOf: lastUpdated,
             Games: games ?? []
         );
     }

--- a/backend/src/HockeyHub.Data/Services/Queries/StandingsQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/StandingsQueryService.cs
@@ -39,10 +39,14 @@ public class StandingsQueryService(HockeyHubDbContext db, RedisCacheService cach
             };
         }, RedisCacheService.StandingsTtl, ct);
 
+        var lastUpdated = await db.StandingsSnapshots
+            .Where(s => s.SeasonId == season.Id)
+            .MaxAsync(s => (DateTimeOffset?)s.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+
         return new StandingsResponse(
             Season: season.Label,
             View: view,
-            DataAsOf: DateTimeOffset.UtcNow,
+            DataAsOf: lastUpdated,
             Groups: groups ?? []
         );
     }

--- a/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/TeamsQueryService.cs
@@ -46,7 +46,10 @@ public class TeamsQueryService(HockeyHubDbContext db, RedisCacheService cache)
             }).ToList();
         }, RedisCacheService.TeamsTtl, ct);
 
-        return new TeamsListResponse(teams ?? []);
+        var lastUpdated = await db.StandingsSnapshots
+            .MaxAsync(s => (DateTimeOffset?)s.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+
+        return new TeamsListResponse(teams ?? [], lastUpdated);
     }
 
     public async Task<TeamProfileResponse?> GetTeamProfileAsync(int teamId, CancellationToken ct = default)
@@ -111,7 +114,7 @@ public class TeamsQueryService(HockeyHubDbContext db, RedisCacheService cache)
                 )).ToList(),
                 Season: season?.Label,
                 Roster: roster,
-                DataAsOf: DateTimeOffset.UtcNow
+                DataAsOf: standings?.LastUpdated ?? DateTimeOffset.UtcNow
             );
         }, RedisCacheService.RosterTtl, ct);
     }
@@ -119,7 +122,7 @@ public class TeamsQueryService(HockeyHubDbContext db, RedisCacheService cache)
 
 // ── List DTOs ──────────────────────────────────────────────────────────────────
 
-public record TeamsListResponse(IReadOnlyList<TeamsListItemDto> Teams);
+public record TeamsListResponse(IReadOnlyList<TeamsListItemDto> Teams, DateTimeOffset DataAsOf);
 
 public record TeamsListItemDto(
     int Id,

--- a/backend/src/HockeyHub.Data/Services/Queries/TradesQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/TradesQueryService.cs
@@ -60,9 +60,13 @@ public class TradesQueryService(HockeyHubDbContext db, RedisCacheService cache)
             }).ToList();
         }, TimeSpan.FromHours(3), ct);
 
+        var lastUpdated = await db.Trades
+            .Where(t => t.SeasonId == season.Id)
+            .MaxAsync(t => (DateTimeOffset?)t.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+
         return new TradesListResponse(
             Season: season.Label,
-            DataAsOf: DateTimeOffset.UtcNow,
+            DataAsOf: lastUpdated,
             Trades: trades ?? []
         );
     }

--- a/frontend/src/app/components/game-hub/game-hub-page/game-hub-page.ts
+++ b/frontend/src/app/components/game-hub/game-hub-page/game-hub-page.ts
@@ -8,12 +8,13 @@ import {
   GameHubApiService, GameHubResponse, GameEvent,
 } from '../../../services/gamehub-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 type Tab = 'team-stats' | 'player-stats';
 
 @Component({
   selector: 'app-game-hub-page',
-  imports: [RouterLink],
+  imports: [RouterLink, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="hub-page">
@@ -40,6 +41,7 @@ type Tab = 'team-stats' | 'player-stats';
           @if (g.arena) {
             <div class="game-header__detail">{{ g.arena.name }}{{ g.arena.city ? ', ' + g.arena.city : '' }}</div>
           }
+          <div class="game-header__detail"><app-data-as-of [timestamp]="g.dataAsOf" /></div>
         </div>
 
         <!-- Tab Bar -->

--- a/frontend/src/app/components/schedule/schedule-page/schedule-page.ts
+++ b/frontend/src/app/components/schedule/schedule-page/schedule-page.ts
@@ -15,19 +15,18 @@ import {
   ScheduleMonth,
 } from '../../../services/schedule-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 @Component({
   selector: 'app-schedule-page',
-  imports: [RouterLink],
+  imports: [RouterLink, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="schedule-page">
       <header class="page-header">
         <h1 class="page-title">{{ data()?.season ?? '...' }} NHL Schedule</h1>
         <p class="page-subtitle">
-          @if (data()) {
-            Updated {{ formatDate(data()!.dataAsOf) }}
-          } @else { &nbsp; }
+          <app-data-as-of [timestamp]="data()?.dataAsOf ?? null" />
         </p>
       </header>
 
@@ -150,11 +149,6 @@ export class SchedulePage implements OnInit {
 
   prevMonth(): void { this.monthIndex.update(i => Math.max(0, i - 1)); }
   nextMonth(): void { this.monthIndex.update(i => Math.min(this.allMonths().length - 1, i + 1)); }
-
-  formatDate(iso: string): string {
-    try { return new Date(iso).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' }); }
-    catch { return ''; }
-  }
 
   formatDayHeader(dateStr: string): string {
     try {

--- a/frontend/src/app/components/scores/scores-page/scores-page.ts
+++ b/frontend/src/app/components/scores/scores-page/scores-page.ts
@@ -8,15 +8,16 @@ import { ExpandedScoreBox } from '../expanded-score-box/expanded-score-box';
 import { PregameMatchup } from '../pregame-matchup/pregame-matchup';
 import { CalendarPicker } from '../calendar-picker/calendar-picker';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 @Component({
   selector: 'app-scores-page',
-  imports: [ScoreBox, ExpandedScoreBox, PregameMatchup, CalendarPicker],
+  imports: [ScoreBox, ExpandedScoreBox, PregameMatchup, CalendarPicker, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="scores-page">
       <div class="scores-header">
-        <h1 class="scores-title">Scores</h1>
+        <h1 class="scores-title">Scores <app-data-as-of [timestamp]="scoresData()?.dataAsOf ?? null" /></h1>
         <div class="scores-date-controls">
           <button class="date-nav" (click)="navigateDate(-1)" aria-label="Previous day">&laquo;</button>
           <button class="date-display" (click)="showCalendar.set(!showCalendar())">

--- a/frontend/src/app/components/shared/data-as-of/data-as-of.ts
+++ b/frontend/src/app/components/shared/data-as-of/data-as-of.ts
@@ -1,0 +1,59 @@
+import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-data-as-of',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (timestamp()) {
+      <span class="data-as-of" [attr.title]="fullTimestamp()">
+        Data updated {{ relativeTime() }}
+      </span>
+    }
+  `,
+  styles: [`
+    .data-as-of {
+      font-size: 0.68rem;
+      color: var(--text-muted);
+      letter-spacing: 0.02em;
+      cursor: help;
+    }
+  `]
+})
+export class DataAsOf {
+  timestamp = input<string | null>(null);
+
+  relativeTime(): string {
+    const iso = this.timestamp();
+    if (!iso) return '';
+    try {
+      const d = new Date(iso);
+      const now = Date.now();
+      const diffMs = now - d.getTime();
+      if (diffMs < 0) return 'just now';
+      const diffSec = Math.floor(diffMs / 1000);
+      if (diffSec < 60) return 'just now';
+      const diffMin = Math.floor(diffSec / 60);
+      if (diffMin < 60) return `${diffMin}m ago`;
+      const diffHr = Math.floor(diffMin / 60);
+      if (diffHr < 24) return `${diffHr}h ago`;
+      const diffDays = Math.floor(diffHr / 24);
+      return `${diffDays}d ago`;
+    } catch {
+      return '';
+    }
+  }
+
+  fullTimestamp(): string {
+    const iso = this.timestamp();
+    if (!iso) return '';
+    try {
+      const d = new Date(iso);
+      return d.toLocaleString(undefined, {
+        month: 'short', day: 'numeric', year: 'numeric',
+        hour: 'numeric', minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  }
+}

--- a/frontend/src/app/components/standings/standings-page/standings-page.ts
+++ b/frontend/src/app/components/standings/standings-page/standings-page.ts
@@ -18,6 +18,7 @@ import {
   StandingsView,
 } from '../../../services/standings-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 type SortColumn =
   | 'gamesPlayed'
@@ -61,18 +62,14 @@ const COLUMNS: readonly ColumnDef[] = [
 
 @Component({
   selector: 'app-standings-page',
-  imports: [NgTemplateOutlet],
+  imports: [NgTemplateOutlet, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="standings-page">
       <header class="page-header">
         <h1 class="page-title">{{ data()?.season ?? '...' }} NHL Standings</h1>
         <p class="page-subtitle">
-          @if (data()) {
-            Updated {{ formatDate(data()!.dataAsOf) }}
-          } @else {
-            &nbsp;
-          }
+          <app-data-as-of [timestamp]="data()?.dataAsOf ?? null" />
         </p>
       </header>
 
@@ -405,12 +402,4 @@ export class StandingsPage implements OnInit {
     return '0';
   }
 
-  formatDate(iso: string): string {
-    try {
-      const d = new Date(iso);
-      return d.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
-    } catch {
-      return '';
-    }
-  }
 }

--- a/frontend/src/app/components/teams/team-profile/team-profile.ts
+++ b/frontend/src/app/components/teams/team-profile/team-profile.ts
@@ -3,10 +3,11 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TeamsApiService, TeamProfile } from '../../../services/teams-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 @Component({
   selector: 'app-team-profile',
-  imports: [RouterLink],
+  imports: [RouterLink, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="profile-page">
@@ -32,6 +33,7 @@ import { DEFAULT_LEAGUE_ID } from '../../../constants';
                 @if (t.divisionRank) { &middot; {{ ordinal(t.divisionRank) }} in division }
               </div>
             }
+            <app-data-as-of [timestamp]="t.dataAsOf" />
           </div>
         </header>
 

--- a/frontend/src/app/components/teams/teams-index/teams-index.ts
+++ b/frontend/src/app/components/teams/teams-index/teams-index.ts
@@ -3,14 +3,16 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TeamsApiService, TeamListItem } from '../../../services/teams-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 @Component({
   selector: 'app-teams-index',
-  imports: [RouterLink],
+  imports: [RouterLink, DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="teams-page">
       <h1 class="page-title">NHL Teams</h1>
+      <p class="page-subtitle"><app-data-as-of [timestamp]="dataAsOf()" /></p>
 
       @if (errorMessage()) {
         <div class="state-msg state-error">{{ errorMessage() }}</div>
@@ -75,6 +77,7 @@ export class TeamsIndex implements OnInit {
 
   leagueId = signal(DEFAULT_LEAGUE_ID);
   teams = signal<TeamListItem[]>([]);
+  dataAsOf = signal<string | null>(null);
   loading = signal(true);
   errorMessage = signal<string | null>(null);
 
@@ -90,7 +93,7 @@ export class TeamsIndex implements OnInit {
     this.api.getTeams(this.leagueId()).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
-      next: res => { this.teams.set(res.teams); this.loading.set(false); },
+      next: res => { this.teams.set(res.teams); this.dataAsOf.set(res.dataAsOf); this.loading.set(false); },
       error: () => { this.loading.set(false); this.errorMessage.set('Unable to load teams.'); }
     });
   }

--- a/frontend/src/app/components/trades/trades-list/trades-list.ts
+++ b/frontend/src/app/components/trades/trades-list/trades-list.ts
@@ -6,15 +6,17 @@ import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TradesApiService, TradeItem } from '../../../services/trades-api.service';
 import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
 
 @Component({
   selector: 'app-trades-list',
+  imports: [DataAsOf],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="trades-page">
       <h1 class="page-title">{{ data()?.season ?? '...' }} NHL Trades</h1>
       <p class="page-subtitle">
-        @if (data()) { {{ data()!.trades.length }} trades this season } @else { &nbsp; }
+        @if (data()) { {{ data()!.trades.length }} trades this season &mdash; <app-data-as-of [timestamp]="data()!.dataAsOf" /> } @else { &nbsp; }
       </p>
 
       @if (errorMessage()) {
@@ -94,7 +96,7 @@ export class TradesList implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   leagueId = signal(DEFAULT_LEAGUE_ID);
-  data = signal<{ season: string; trades: TradeItem[] } | null>(null);
+  data = signal<{ season: string; trades: TradeItem[]; dataAsOf: string } | null>(null);
   trades = signal<TradeItem[]>([]);
   loading = signal(true);
   errorMessage = signal<string | null>(null);

--- a/frontend/src/app/services/teams-api.service.ts
+++ b/frontend/src/app/services/teams-api.service.ts
@@ -5,6 +5,7 @@ import { API_BASE_URL } from '../constants';
 
 export interface TeamsListResponse {
   teams: TeamListItem[];
+  dataAsOf: string;
 }
 
 export interface TeamListItem {


### PR DESCRIPTION
Backend: Changed 6 query services (Scores, Standings, Schedule, Trades, GameHub, Teams) from hardcoded DateTimeOffset.UtcNow to actual MAX(LastUpdated) from DB entities (Game, StandingsSnapshot, Trade). Added DataAsOf to TeamsListResponse.

Frontend: Created shared DataAsOf component showing relative time ("3m ago", "2h ago") with full timestamp on hover. Wired into all data pages: scores, standings, schedule, trades, game hub, teams index, and team profile. Replaced inline formatDate in standings and schedule with the shared component.