### PR TITLE
Add Stats page: PlayerSeason entity, NHL API sync, query service, full frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-11
 backend/
 ├── src/
 │   ├── HockeyHub.Core/             # Entities + interfaces (no dependencies)
-│   │   ├── Models/Entities/         # League, Team, Season, Arena, Player, Personnel, FranchiseHistory, Game, GamePeriodScore, StandingsSnapshot, Trade, TradeAsset
+│   │   ├── Models/Entities/         # League, Team, Season, Arena, Player, Personnel, FranchiseHistory, Game, GamePeriodScore, StandingsSnapshot, Trade, TradeAsset, PlayerSeason
 │   │   ├── Providers/               # INhlDataProvider interface + DTOs, IScoreBroadcaster
 │   │   └── NhlDateHelper.cs         # Shared NHL game day boundary logic (3 AM ET cutoff, DST-aware)
 │   ├── HockeyHub.Data/             # Data access (depends on Core)
@@ -20,10 +20,10 @@ backend/
 │   │   ├── Providers/NhlWebApiProvider.cs
 │   │   └── Services/
 │   │       ├── Cache/               # Redis cache service
-│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync, TradeSync jobs
-│   │       └── Queries/             # Scores, Standings, Schedule, Teams, GameHub, Trades, SeasonMode, PlayoffBracket, Draft query services
+│   │       ├── Sync/                # DataSeed, ScoresSync, StandingsSync, ScheduleSync, TradeSync, StatsSync jobs
+│   │       └── Queries/             # Scores, Standings, Schedule, Teams, GameHub, Trades, SeasonMode, PlayoffBracket, Draft, Stats query services
 │   └── HockeyHub.Api/              # HTTP host (depends on Data + Core)
-│       ├── Controllers/             # Scores (5), Standings, Schedule, Teams (2), GameHub, Trades, Search, Health, SeasonMode, PlayoffBracket, Draft
+│       ├── Controllers/             # Scores (5), Standings, Schedule, Teams (2), GameHub, Trades, Search, Health, SeasonMode, PlayoffBracket, Draft, Stats
 │       ├── Hubs/                    # GameHub, SignalRScoreBroadcaster
 │       ├── Middleware/              # Error handling, DataAsOf wrapper
 │       ├── Program.cs              # App startup + DI wiring
@@ -56,9 +56,10 @@ frontend/
 │   │   ├── trades/                # TradesList (chronological trade cards)
 │   │   ├── playoffs/              # PlayoffBracketPage (conference tabs, matchup cards), MatchupDetailPage
 │   │   ├── draft/                 # DraftPage (round tabs, pick table with clickable player links)
-│   │   └── [stats,...]/           # Placeholder route components (5 remaining)
+│   │   ├── stats/                 # StatsPage (6 section tabs, sortable columns, server-side pagination)
+│   │   └── [players,...]/         # Placeholder route components (4 remaining)
 │   ├── constants.ts               # Shared constants (league ID, polling intervals, SignalR config, close-game thresholds, getPeriodLabel)
-│   ├── services/                  # Theme, SignalR, ScoresApi, StandingsApi, ScheduleApi, SearchApi, TeamsApi, GameHubApi, TradesApi, GameClock, SeasonMode, PlayoffsApi, DraftApi
+│   ├── services/                  # Theme, SignalR, ScoresApi, StandingsApi, ScheduleApi, SearchApi, TeamsApi, GameHubApi, TradesApi, GameClock, SeasonMode, PlayoffsApi, DraftApi, StatsApi
 │   ├── directives/                # TooltipDirective
 │   ├── pipes/                     # EraPipe, TimezonePipe
 │   ├── app.routes.ts              # 18 lazy-loaded routes (incl. game-hub/:gameId, teams/:teamId, playoffs, playoffs/matchup/:seriesLetter, draft)
@@ -114,7 +115,7 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - NHL data sourced via `INhlDataProvider` interface (Core) — implemented by `NhlWebApiProvider` (Data), swappable to licensed provider later
 - `IScoreBroadcaster` interface (Core) abstracts SignalR broadcasting — implemented by `SignalRScoreBroadcaster` (Api) to maintain dependency flow
 - SignalR `GameHub` at `/hubs/scores` for live score push, Redis backplane for multi-server
-- Hangfire recurring jobs: `ScoresSyncJob` (every 15s), `StandingsSyncJob` (every 5min), `ScheduleSyncJob` (daily 6 AM UTC), `TradeSyncJob` (daily 7 AM UTC), dashboard at `/hangfire`
+- Hangfire recurring jobs: `ScoresSyncJob` (every 15s), `StandingsSyncJob` (every 5min), `StatsSyncJob` (every 10min), `ScheduleSyncJob` (daily 6 AM UTC), `TradeSyncJob` (daily 7 AM UTC), dashboard at `/hangfire`
 - Response wrappers: `DataAsOfResponse<T>` and `PaginatedResponse<T>` in Api/Middleware/
 - Connection strings in appsettings.json for local dev (DefaultConnection: SQL Server on port 1433, Redis: `localhost:6379`); deployed environments inject via Key Vault secret refs → Container App env vars (`ConnectionStrings__DefaultConnection`, `ConnectionStrings__Redis`)
 - EF migrations live in HockeyHub.Data; run `dotnet ef` from Api project with `--project ../HockeyHub.Data`
@@ -127,6 +128,7 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - **Playoffs/Draft data strategy**: No new database entities — playoff bracket and draft data served via Redis-cached NHL API calls (same pattern as Game Hub). Avoids migration complexity for read-only, single-season data. Provider methods: `GetPlayoffBracketAsync` (`/v1/playoff-bracket/{season}`), `GetDraftAsync` (`/v1/draft/{year}`)
 
 ## Recent Changes
+- Stats page (US4): `PlayerSeason` entity with full skater/goalie stat fields (nullable for historical eras), `Position` field added to `Player` entity. EF migration `AddPlayerSeasonAndPosition`. `GetSkaterStatsAsync`/`GetGoalieStatsAsync` added to `INhlDataProvider` — implemented in `NhlWebApiProvider` using NHL Stats REST API (`api.nhle.com/stats/rest/en/skater/summary` + `goalie/summary`) with pagination. `StatsSyncJob` (Hangfire, every 10min) syncs all player season stats into DB with composite `(PlayerId, TeamId)` key to handle mid-season trades. `StatsQueryService` caches full DTO list per section (6 sections: all-players, all-goalies, all-forwards, all-defensemen, rookie-players, rookie-goalies) with 3h Redis TTL, sorts/paginates in memory. `StatsController` exposes `GET /api/leagues/{leagueId}/stats`. Frontend: `StatsApiService` + full `StatsPage` component with 6 section tabs, 17 sortable skater columns / 12 goalie columns, server-side pagination, responsive layout.
 - Playoffs, draft, and season mode implementation: `SeasonModeService` determines regular-season/playoffs/off-season from game data (1h Redis cache), `PlayoffBracketQueryService` serves bracket + matchup detail from NHL API `/v1/playoff-bracket/{season}` (5min cache), `DraftQueryService` serves draft picks from `/v1/draft/{year}` (10s on draft day, 24h otherwise) with player ID resolution from DB. Three controllers: `SeasonModeController` (`GET /api/leagues/{id}/season-mode`), `PlayoffBracketController` (`GET .../playoffs/bracket?conference=` + `GET .../playoffs/matchup/{seriesLetter}`), `DraftController` (`GET .../draft?year=`). Zero new entities/migrations — all data via Redis-cached NHL API calls. Frontend: `PlayoffBracketPage` (conference tabs, round grouping, clickable matchup cards), `MatchupDetailPage` (series game results), `DraftPage` (round tabs, pick table with clickable player links). Nav bar now season-mode-aware (adds Playoffs link during playoffs, replaces Scores with Draft during off-season). Three new Angular services: `SeasonModeService`, `PlayoffsApiService`, `DraftApiService`. Three new routes: `:leagueId/playoffs`, `:leagueId/playoffs/matchup/:seriesLetter`, `:leagueId/draft`.
 - Playoff brackets mockup (13): Standings gets Playoffs/Regular Season top tabs, bracket views (Eastern/Western/Full League sub-tabs), matchup boxes with seed + record, clickable to matchup detail page. Detail page has H2H regular season stats + matchup summary (left) and all-time playoff stats + all-time H2H (right). Round 2+ adds "Current Playoff Stats" section.
 - Playoff stats mockup (14): Stats section gets Playoffs/Regular Season top tabs. Same table structure with playoff data for team stats (16 teams by WIN%), skater stats (top 10 by points), and goalie stats (top 10 by Sv%).
@@ -169,9 +171,9 @@ C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standa
 - **SQL admin password rotation**: Initial deploy password is in shell history
 
 ### Missing Implementation
-- **Database entities (12 missing)**: PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerSeason, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, ImportantDate, RuleBook _(PlayoffSeries, PlayoffRound, DraftPick, DraftProspect, OffSeasonEvent, PlayoffTeamStats were planned but not needed — playoffs/draft served via cached NHL API calls with no new entities)_
-- **API endpoints (12 missing)**: Stats (1), Players (2), Salary Cap (5), Free Agents (1), Personnel (1), Teams roster (1), Teams depth chart (1) _(Playoff brackets (2), Draft (1), Season mode (1) are now implemented; Playoff stats (2) and Off-season schedule (1) still pending)_
-- **Frontend pages (5 placeholders + 1 new)**: Stats, Players, Salary Cap, Free Agents, Personnel — all currently render placeholder text. Off-Season Schedule not yet started. _(Playoff Brackets, Matchup Detail, and Draft pages are now implemented)_
+- **Database entities (11 missing)**: PlayerPosition, PlayerHeadshot, PlayerStyle, PlayerTeamHistory, PlayerAward, Contract, ContractYear, GameEvent, GamePlayerStat, ImportantDate, RuleBook _(PlayerSeason now implemented; PlayoffSeries, PlayoffRound, DraftPick, DraftProspect, OffSeasonEvent, PlayoffTeamStats were planned but not needed — playoffs/draft served via cached NHL API calls with no new entities)_
+- **API endpoints (11 missing)**: Players (2), Salary Cap (5), Free Agents (1), Personnel (1), Teams roster (1), Teams depth chart (1) _(Stats (1), Playoff brackets (2), Draft (1), Season mode (1) are now implemented; Playoff stats (2) and Off-season schedule (1) still pending)_
+- **Frontend pages (4 placeholders + 1 new)**: Players, Salary Cap, Free Agents, Personnel — all currently render placeholder text. Off-Season Schedule not yet started. _(Stats, Playoff Brackets, Matchup Detail, and Draft pages are now implemented)_
 
 ### Data Quality Bugs in NhlWebApiProvider
 - _~~`GetStandingsAsync` PP%/PK%/FO% always 0~~ — Fixed. The NHL standings endpoint (`api-web.nhle.com/v1/standings`) doesn't include these fields. `StandingsSyncJob` now fetches them from the NHL Stats REST API (`api.nhle.com/stats/rest/en/team/summary`) and merges them during sync. Values stored as percentages (e.g. 24.8, not 0.248)._

--- a/backend/src/HockeyHub.Api/Controllers/StatsController.cs
+++ b/backend/src/HockeyHub.Api/Controllers/StatsController.cs
@@ -1,0 +1,46 @@
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Queries;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class StatsController(StatsQueryService statsQuery, HockeyHubDbContext db) : ControllerBase
+{
+    [HttpGet("leagues/{leagueId}/stats")]
+    public async Task<IActionResult> GetStats(
+        string leagueId,
+        [FromQuery] string section = "all-players",
+        [FromQuery] string? sort = null,
+        [FromQuery] string sortDir = "desc",
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        if (!statsQuery.IsValidSection(section))
+            return BadRequest($"Invalid section '{section}'. Allowed: all-players, all-goalies, all-forwards, all-defensemen, rookie-players, rookie-goalies.");
+
+        if (page < 1) page = 1;
+        if (pageSize < 1 || pageSize > 100) pageSize = 50;
+
+        var id = await ResolveLeagueId(leagueId, ct);
+        if (id is null) return NotFound("League not found");
+
+        var result = await statsQuery.GetStatsAsync(id.Value, section, sort, sortDir, page, pageSize, ct);
+        if (result is null) return NotFound("No current season found for league");
+
+        return Ok(result);
+    }
+
+    private async Task<int?> ResolveLeagueId(string leagueId, CancellationToken ct)
+    {
+        if (int.TryParse(leagueId, out var numericId))
+            return numericId;
+
+        var league = await db.Leagues
+            .FirstOrDefaultAsync(l => l.Abbreviation.ToLower() == leagueId.ToLower(), ct);
+        return league?.Id;
+    }
+}

--- a/backend/src/HockeyHub.Api/Program.cs
+++ b/backend/src/HockeyHub.Api/Program.cs
@@ -67,10 +67,12 @@ builder.Services.AddScoped<TradesQueryService>();
 builder.Services.AddScoped<SeasonModeService>();
 builder.Services.AddScoped<PlayoffBracketQueryService>();
 builder.Services.AddScoped<DraftQueryService>();
+builder.Services.AddScoped<StatsQueryService>();
 builder.Services.AddScoped<TradeSyncJob>();
 builder.Services.AddScoped<ScoresSyncJob>();
 builder.Services.AddScoped<StandingsSyncJob>();
 builder.Services.AddScoped<ScheduleSyncJob>();
+builder.Services.AddScoped<StatsSyncJob>();
 builder.Services.AddSingleton<IScoreBroadcaster, SignalRScoreBroadcaster>();
 
 // Response compression
@@ -166,6 +168,11 @@ app.Services.GetRequiredService<IRecurringJobManager>().AddOrUpdate<TradeSyncJob
     "trade-sync",
     job => job.SyncAsync(CancellationToken.None),
     "0 7 * * *"); // Daily at 7 AM UTC
+
+app.Services.GetRequiredService<IRecurringJobManager>().AddOrUpdate<StatsSyncJob>(
+    "stats-sync",
+    job => job.SyncAsync(CancellationToken.None),
+    "*/10 * * * *"); // Every 10 minutes
 
 // Data seed command: dotnet run -- --seed [--current-only]
 if (args.Contains("--seed"))

--- a/backend/src/HockeyHub.Core/Models/Entities/Player.cs
+++ b/backend/src/HockeyHub.Core/Models/Entities/Player.cs
@@ -18,6 +18,7 @@ public class Player
     public int? DraftPick { get; set; }
     public int? DraftTeamId { get; set; }
     public int? CurrentTeamId { get; set; }
+    public required string Position { get; set; }
     public int? JerseyNumber { get; set; }
     public bool IsActive { get; set; }
     public bool IsEbug { get; set; }

--- a/backend/src/HockeyHub.Core/Models/Entities/PlayerSeason.cs
+++ b/backend/src/HockeyHub.Core/Models/Entities/PlayerSeason.cs
@@ -1,0 +1,65 @@
+namespace HockeyHub.Core.Models.Entities;
+
+/// <summary>
+/// Per-player, per-team, per-season stat line.
+/// Many fields are nullable to handle historical eras where they weren't tracked.
+/// Goalie-specific fields are null for skaters.
+/// </summary>
+public class PlayerSeason
+{
+    public int Id { get; set; }
+    public int PlayerId { get; set; }
+    public int TeamId { get; set; }
+    public int SeasonId { get; set; }
+    public required string LeagueAbbreviation { get; set; }
+    public required string Era { get; set; }
+
+    // ── Skater stats ────────────────────────────────────────────────
+    public int GamesPlayed { get; set; }
+    public int Goals { get; set; }
+    public int Assists { get; set; }
+    public int Points { get; set; }
+    public int PlusMinus { get; set; }
+    public int? Hits { get; set; }
+    public int PenaltyMinutes { get; set; }
+    public decimal? TimeOnIcePerGame { get; set; }
+    public int? Shots { get; set; }
+    public decimal? ShootingPct { get; set; }
+    public int? BlockedShots { get; set; }
+    public int? EvenStrengthPoints { get; set; }
+    public int? PowerPlayPoints { get; set; }
+    public int? ShortHandedPoints { get; set; }
+    public int? Giveaways { get; set; }
+    public int? Takeaways { get; set; }
+    public decimal? FaceoffPct { get; set; }
+    public decimal? ShootoutPct { get; set; }
+
+    // ── Advanced stats (null until analytics provider integrated) ────
+    public decimal? War { get; set; }
+    public decimal? XGFPer60 { get; set; }
+    public decimal? XGAPer60 { get; set; }
+
+    // ── Goalie-specific stats (null for skaters) ────────────────────
+    public int? Wins { get; set; }
+    public int? Losses { get; set; }
+    public int? OvertimeLosses { get; set; }
+    public decimal? SavePct { get; set; }
+    public decimal? GoalsAgainstAvg { get; set; }
+    public int? ShotsAgainst { get; set; }
+    public int? Saves { get; set; }
+    public int? GoalsAgainst { get; set; }
+    public int? GamesStarted { get; set; }
+    public int? HighDangerChances { get; set; }
+    public int? HighDangerSaves { get; set; }
+    public int? LowDangerChances { get; set; }
+    public int? LowDangerSaves { get; set; }
+    public int? GoalieGoals { get; set; }
+    public int? GoalieAssists { get; set; }
+
+    public DateTimeOffset LastUpdated { get; set; }
+
+    // Navigation
+    public Player Player { get; set; } = null!;
+    public Team Team { get; set; } = null!;
+    public Season Season { get; set; } = null!;
+}

--- a/backend/src/HockeyHub.Core/Providers/INhlDataProvider.cs
+++ b/backend/src/HockeyHub.Core/Providers/INhlDataProvider.cs
@@ -14,6 +14,8 @@ public interface INhlDataProvider
     Task<IReadOnlyList<NhlTeamSeasonStats>> GetTeamSeasonStatsAsync(string season, CancellationToken ct = default);
     Task<NhlPlayoffBracketData?> GetPlayoffBracketAsync(string season, CancellationToken ct = default);
     Task<NhlDraftData?> GetDraftAsync(int year, CancellationToken ct = default);
+    Task<IReadOnlyList<NhlSkaterSeasonStats>> GetSkaterStatsAsync(string season, CancellationToken ct = default);
+    Task<IReadOnlyList<NhlGoalieSeasonStats>> GetGoalieStatsAsync(string season, CancellationToken ct = default);
 }
 
 public record NhlTeamData(
@@ -263,4 +265,48 @@ public record NhlDraftPick(
     string? PreviousClub,
     string? PreviousLeague,
     int? PlayerId
+);
+
+// ── Player Season Stats DTOs ─────────────────────────────────────
+
+public record NhlSkaterSeasonStats(
+    int PlayerId,
+    string FullName,
+    string TeamAbbreviation,
+    string PositionCode,
+    int GamesPlayed,
+    int Goals,
+    int Assists,
+    int Points,
+    int PlusMinus,
+    int PenaltyMinutes,
+    int? Hits,
+    decimal? TimeOnIcePerGame,
+    int? Shots,
+    decimal? ShootingPct,
+    int? BlockedShots,
+    int? EvenStrengthPoints,
+    int? PowerPlayPoints,
+    int? ShortHandedPoints,
+    int? Giveaways,
+    int? Takeaways,
+    decimal? FaceoffPct
+);
+
+public record NhlGoalieSeasonStats(
+    int PlayerId,
+    string FullName,
+    string TeamAbbreviation,
+    int GamesPlayed,
+    int GamesStarted,
+    int Wins,
+    int Losses,
+    int OvertimeLosses,
+    decimal SavePct,
+    decimal GoalsAgainstAvg,
+    int ShotsAgainst,
+    int Saves,
+    int GoalsAgainst,
+    int Goals,
+    int Assists
 );

--- a/backend/src/HockeyHub.Data/Data/HockeyHubDbContext.cs
+++ b/backend/src/HockeyHub.Data/Data/HockeyHubDbContext.cs
@@ -18,6 +18,7 @@ public class HockeyHubDbContext(DbContextOptions<HockeyHubDbContext> options) : 
     public DbSet<StandingsSnapshot> StandingsSnapshots => Set<StandingsSnapshot>();
     public DbSet<Trade> Trades => Set<Trade>();
     public DbSet<TradeAsset> TradeAssets => Set<TradeAsset>();
+    public DbSet<PlayerSeason> PlayerSeasons => Set<PlayerSeason>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -76,6 +77,7 @@ public class HockeyHubDbContext(DbContextOptions<HockeyHubDbContext> options) : 
             entity.HasIndex(e => e.ExternalId).IsUnique();
             entity.HasIndex(e => e.CurrentTeamId);
             entity.HasIndex(e => e.IsActive);
+            entity.HasIndex(e => e.Position);
 
             entity.HasOne(e => e.CurrentTeam)
                 .WithMany(t => t.Players)
@@ -183,6 +185,38 @@ public class HockeyHubDbContext(DbContextOptions<HockeyHubDbContext> options) : 
             entity.HasOne(e => e.Team)
                 .WithMany()
                 .HasForeignKey(e => e.TeamId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<PlayerSeason>(entity =>
+        {
+            entity.HasIndex(e => new { e.PlayerId, e.TeamId, e.SeasonId, e.LeagueAbbreviation }).IsUnique();
+            entity.HasIndex(e => new { e.SeasonId, e.LeagueAbbreviation });
+            entity.HasIndex(e => new { e.TeamId, e.SeasonId });
+
+            entity.Property(e => e.TimeOnIcePerGame).HasPrecision(5, 2);
+            entity.Property(e => e.ShootingPct).HasPrecision(5, 1);
+            entity.Property(e => e.FaceoffPct).HasPrecision(5, 1);
+            entity.Property(e => e.ShootoutPct).HasPrecision(5, 1);
+            entity.Property(e => e.War).HasPrecision(5, 2);
+            entity.Property(e => e.XGFPer60).HasPrecision(5, 2);
+            entity.Property(e => e.XGAPer60).HasPrecision(5, 2);
+            entity.Property(e => e.SavePct).HasPrecision(5, 3);
+            entity.Property(e => e.GoalsAgainstAvg).HasPrecision(5, 2);
+
+            entity.HasOne(e => e.Player)
+                .WithMany()
+                .HasForeignKey(e => e.PlayerId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(e => e.Team)
+                .WithMany()
+                .HasForeignKey(e => e.TeamId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(e => e.Season)
+                .WithMany()
+                .HasForeignKey(e => e.SeasonId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
     }

--- a/backend/src/HockeyHub.Data/Migrations/20260414021926_AddPlayerSeasonAndPosition.Designer.cs
+++ b/backend/src/HockeyHub.Data/Migrations/20260414021926_AddPlayerSeasonAndPosition.Designer.cs
@@ -4,6 +4,7 @@ using HockeyHub.Data.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HockeyHub.Data.Migrations
 {
     [DbContext(typeof(HockeyHubDbContext))]
-    partial class HockeyHubDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414021926_AddPlayerSeasonAndPosition")]
+    partial class AddPlayerSeasonAndPosition
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/HockeyHub.Data/Migrations/20260414021926_AddPlayerSeasonAndPosition.cs
+++ b/backend/src/HockeyHub.Data/Migrations/20260414021926_AddPlayerSeasonAndPosition.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HockeyHub.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerSeasonAndPosition : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Position",
+                table: "Players",
+                type: "nvarchar(450)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "PlayerSeasons",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PlayerId = table.Column<int>(type: "int", nullable: false),
+                    TeamId = table.Column<int>(type: "int", nullable: false),
+                    SeasonId = table.Column<int>(type: "int", nullable: false),
+                    LeagueAbbreviation = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Era = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    GamesPlayed = table.Column<int>(type: "int", nullable: false),
+                    Goals = table.Column<int>(type: "int", nullable: false),
+                    Assists = table.Column<int>(type: "int", nullable: false),
+                    Points = table.Column<int>(type: "int", nullable: false),
+                    PlusMinus = table.Column<int>(type: "int", nullable: false),
+                    Hits = table.Column<int>(type: "int", nullable: true),
+                    PenaltyMinutes = table.Column<int>(type: "int", nullable: false),
+                    TimeOnIcePerGame = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: true),
+                    Shots = table.Column<int>(type: "int", nullable: true),
+                    ShootingPct = table.Column<decimal>(type: "decimal(5,1)", precision: 5, scale: 1, nullable: true),
+                    BlockedShots = table.Column<int>(type: "int", nullable: true),
+                    EvenStrengthPoints = table.Column<int>(type: "int", nullable: true),
+                    PowerPlayPoints = table.Column<int>(type: "int", nullable: true),
+                    ShortHandedPoints = table.Column<int>(type: "int", nullable: true),
+                    Giveaways = table.Column<int>(type: "int", nullable: true),
+                    Takeaways = table.Column<int>(type: "int", nullable: true),
+                    FaceoffPct = table.Column<decimal>(type: "decimal(5,1)", precision: 5, scale: 1, nullable: true),
+                    ShootoutPct = table.Column<decimal>(type: "decimal(5,1)", precision: 5, scale: 1, nullable: true),
+                    War = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: true),
+                    XGFPer60 = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: true),
+                    XGAPer60 = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: true),
+                    Wins = table.Column<int>(type: "int", nullable: true),
+                    Losses = table.Column<int>(type: "int", nullable: true),
+                    OvertimeLosses = table.Column<int>(type: "int", nullable: true),
+                    SavePct = table.Column<decimal>(type: "decimal(5,3)", precision: 5, scale: 3, nullable: true),
+                    GoalsAgainstAvg = table.Column<decimal>(type: "decimal(5,2)", precision: 5, scale: 2, nullable: true),
+                    ShotsAgainst = table.Column<int>(type: "int", nullable: true),
+                    Saves = table.Column<int>(type: "int", nullable: true),
+                    GoalsAgainst = table.Column<int>(type: "int", nullable: true),
+                    GamesStarted = table.Column<int>(type: "int", nullable: true),
+                    HighDangerChances = table.Column<int>(type: "int", nullable: true),
+                    HighDangerSaves = table.Column<int>(type: "int", nullable: true),
+                    LowDangerChances = table.Column<int>(type: "int", nullable: true),
+                    LowDangerSaves = table.Column<int>(type: "int", nullable: true),
+                    GoalieGoals = table.Column<int>(type: "int", nullable: true),
+                    GoalieAssists = table.Column<int>(type: "int", nullable: true),
+                    LastUpdated = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerSeasons", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlayerSeasons_Players_PlayerId",
+                        column: x => x.PlayerId,
+                        principalTable: "Players",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PlayerSeasons_Seasons_SeasonId",
+                        column: x => x.SeasonId,
+                        principalTable: "Seasons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PlayerSeasons_Teams_TeamId",
+                        column: x => x.TeamId,
+                        principalTable: "Teams",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Players_Position",
+                table: "Players",
+                column: "Position");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerSeasons_PlayerId_TeamId_SeasonId_LeagueAbbreviation",
+                table: "PlayerSeasons",
+                columns: new[] { "PlayerId", "TeamId", "SeasonId", "LeagueAbbreviation" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerSeasons_SeasonId_LeagueAbbreviation",
+                table: "PlayerSeasons",
+                columns: new[] { "SeasonId", "LeagueAbbreviation" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerSeasons_TeamId_SeasonId",
+                table: "PlayerSeasons",
+                columns: new[] { "TeamId", "SeasonId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerSeasons");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Players_Position",
+                table: "Players");
+
+            migrationBuilder.DropColumn(
+                name: "Position",
+                table: "Players");
+        }
+    }
+}

--- a/backend/src/HockeyHub.Data/Providers/NhlWebApiProvider.cs
+++ b/backend/src/HockeyHub.Data/Providers/NhlWebApiProvider.cs
@@ -274,6 +274,133 @@ public class NhlWebApiProvider : INhlDataProvider, IDisposable
         return stats;
     }
 
+    public async Task<IReadOnlyList<NhlSkaterSeasonStats>> GetSkaterStatsAsync(string season, CancellationToken ct = default)
+    {
+        var seasonId = season.Replace("-", "");
+        var stats = new List<NhlSkaterSeasonStats>();
+        var start = 0;
+        const int limit = 100;
+
+        try
+        {
+            while (true)
+            {
+                using var lease = await _rateLimiter.AcquireAsync(1, ct);
+                if (!lease.IsAcquired) break;
+
+                var url = $"https://api.nhle.com/stats/rest/en/skater/summary?cayenneExp=seasonId={seasonId}%20and%20gameTypeId=2&start={start}&limit={limit}";
+                _logger.LogDebug("NHL Stats API request: skater/summary start={Start}", start);
+                using var response = await _http.GetAsync(url, ct);
+                response.EnsureSuccessStatusCode();
+                var json = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, ct);
+
+                if (!json.TryGetProperty("data", out var data)) break;
+                var count = 0;
+
+                foreach (var p in data.EnumerateArray())
+                {
+                    try
+                    {
+                        stats.Add(new NhlSkaterSeasonStats(
+                            PlayerId: p.TryGetProperty("playerId", out var id) ? id.GetInt32() : 0,
+                            FullName: p.TryGetProperty("skaterFullName", out var name) ? name.GetString() ?? "" : "",
+                            TeamAbbreviation: p.TryGetProperty("teamAbbrevs", out var team) ? team.GetString()?.Split(",")[0].Trim() ?? "" : "",
+                            PositionCode: p.TryGetProperty("positionCode", out var pos) ? pos.GetString() ?? "C" : "C",
+                            GamesPlayed: p.TryGetProperty("gamesPlayed", out var gp) ? gp.GetInt32() : 0,
+                            Goals: p.TryGetProperty("goals", out var g) ? g.GetInt32() : 0,
+                            Assists: p.TryGetProperty("assists", out var a) ? a.GetInt32() : 0,
+                            Points: p.TryGetProperty("points", out var pts) ? pts.GetInt32() : 0,
+                            PlusMinus: p.TryGetProperty("plusMinus", out var pm) ? pm.GetInt32() : 0,
+                            PenaltyMinutes: p.TryGetProperty("penaltyMinutes", out var pim) ? pim.GetInt32() : 0,
+                            Hits: p.TryGetProperty("hits", out var hits) ? hits.GetInt32() : null,
+                            TimeOnIcePerGame: p.TryGetProperty("timeOnIcePerGame", out var toi) ? toi.GetDecimal() : null,
+                            Shots: p.TryGetProperty("shots", out var sh) ? sh.GetInt32() : null,
+                            ShootingPct: p.TryGetProperty("shootingPct", out var spct) ? Math.Round(spct.GetDecimal() * 100, 1) : null,
+                            BlockedShots: p.TryGetProperty("blockedShots", out var bs) ? bs.GetInt32() : null,
+                            EvenStrengthPoints: p.TryGetProperty("evPoints", out var evp) ? evp.GetInt32() : null,
+                            PowerPlayPoints: p.TryGetProperty("ppPoints", out var ppp) ? ppp.GetInt32() : null,
+                            ShortHandedPoints: p.TryGetProperty("shPoints", out var shp) ? shp.GetInt32() : null,
+                            Giveaways: p.TryGetProperty("giveaways", out var gv) ? gv.GetInt32() : null,
+                            Takeaways: p.TryGetProperty("takeaways", out var tk) ? tk.GetInt32() : null,
+                            FaceoffPct: p.TryGetProperty("faceoffWinPct", out var fo) ? Math.Round(fo.GetDecimal() * 100, 1) : null
+                        ));
+                        count++;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to parse skater stats entry, skipping");
+                    }
+                }
+
+                if (count < limit) break;
+                start += limit;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch skater season stats from NHL Stats API");
+        }
+
+        _logger.LogInformation("Fetched {Count} skater stat lines", stats.Count);
+        return stats;
+    }
+
+    public async Task<IReadOnlyList<NhlGoalieSeasonStats>> GetGoalieStatsAsync(string season, CancellationToken ct = default)
+    {
+        var seasonId = season.Replace("-", "");
+        var url = $"https://api.nhle.com/stats/rest/en/goalie/summary?cayenneExp=seasonId={seasonId}%20and%20gameTypeId=2&limit=100";
+        var stats = new List<NhlGoalieSeasonStats>();
+
+        try
+        {
+            using var lease = await _rateLimiter.AcquireAsync(1, ct);
+            if (!lease.IsAcquired) return [];
+
+            _logger.LogDebug("NHL Stats API request: goalie/summary for season {Season}", season);
+            using var response = await _http.GetAsync(url, ct);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, ct);
+
+            if (json.TryGetProperty("data", out var data))
+            {
+                foreach (var g in data.EnumerateArray())
+                {
+                    try
+                    {
+                        stats.Add(new NhlGoalieSeasonStats(
+                            PlayerId: g.TryGetProperty("playerId", out var id) ? id.GetInt32() : 0,
+                            FullName: g.TryGetProperty("goalieFullName", out var name) ? name.GetString() ?? "" : "",
+                            TeamAbbreviation: g.TryGetProperty("teamAbbrevs", out var team) ? team.GetString()?.Split(",")[0].Trim() ?? "" : "",
+                            GamesPlayed: g.TryGetProperty("gamesPlayed", out var gp) ? gp.GetInt32() : 0,
+                            GamesStarted: g.TryGetProperty("gamesStarted", out var gs) ? gs.GetInt32() : 0,
+                            Wins: g.TryGetProperty("wins", out var w) ? w.GetInt32() : 0,
+                            Losses: g.TryGetProperty("losses", out var l) ? l.GetInt32() : 0,
+                            OvertimeLosses: g.TryGetProperty("otLosses", out var otl) ? otl.GetInt32() : 0,
+                            SavePct: g.TryGetProperty("savePct", out var svp) ? svp.GetDecimal() : 0,
+                            GoalsAgainstAvg: g.TryGetProperty("goalsAgainstAverage", out var gaa) ? Math.Round(gaa.GetDecimal(), 2) : 0,
+                            ShotsAgainst: g.TryGetProperty("shotsAgainst", out var sa) ? sa.GetInt32() : 0,
+                            Saves: g.TryGetProperty("saves", out var sv) ? sv.GetInt32() : 0,
+                            GoalsAgainst: g.TryGetProperty("goalsAgainst", out var ga) ? ga.GetInt32() : 0,
+                            Goals: g.TryGetProperty("goals", out var goals) ? goals.GetInt32() : 0,
+                            Assists: g.TryGetProperty("assists", out var assists) ? assists.GetInt32() : 0
+                        ));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to parse goalie stats entry, skipping");
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch goalie season stats from NHL Stats API");
+        }
+
+        _logger.LogInformation("Fetched {Count} goalie stat lines", stats.Count);
+        return stats;
+    }
+
     public async Task<NhlPlayoffBracketData?> GetPlayoffBracketAsync(string season, CancellationToken ct = default)
     {
         if (await GetJsonAsync($"v1/playoff-bracket/{season}", ct) is not { } json) return null;

--- a/backend/src/HockeyHub.Data/Services/Queries/StatsQueryService.cs
+++ b/backend/src/HockeyHub.Data/Services/Queries/StatsQueryService.cs
@@ -1,0 +1,300 @@
+using HockeyHub.Core.Models.Entities;
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Cache;
+using Microsoft.EntityFrameworkCore;
+
+namespace HockeyHub.Data.Services.Queries;
+
+public class StatsQueryService(HockeyHubDbContext db, RedisCacheService cache)
+{
+    private static readonly HashSet<string> GoalieSections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "all-goalies", "rookie-goalies"
+    };
+
+    private static readonly HashSet<string> AllSections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "all-players", "all-goalies", "all-forwards", "all-defensemen", "rookie-players", "rookie-goalies"
+    };
+
+    private const string DefaultSkaterSort = "points";
+    private const string DefaultGoalieSort = "wins";
+
+    public async Task<StatsResponse?> GetStatsAsync(
+        int leagueId, string section, string? sort, string sortDir,
+        int page, int pageSize, CancellationToken ct = default)
+    {
+        var season = await db.Seasons
+            .Where(s => s.LeagueId == leagueId && s.IsCurrent)
+            .FirstOrDefaultAsync(ct);
+        if (season is null) return null;
+
+        var isGoalie = GoalieSections.Contains(section);
+        var effectiveSort = sort ?? (isGoalie ? DefaultGoalieSort : DefaultSkaterSort);
+
+        // Cache the full DTO list per section (simple key, easy to invalidate).
+        // Sort and pagination are applied in-memory after cache retrieval.
+        var cacheKey = $"stats:{leagueId}:{section}:{season.Id}";
+
+        if (isGoalie)
+        {
+            var all = await cache.GetOrSetAsync(cacheKey, async _ =>
+            {
+                var items = await BuildQuery(season.Id, section).ToListAsync(ct);
+                return items.Select(MapToGoalieDto).ToList();
+            }, RedisCacheService.StatsTtl, ct) ?? [];
+
+            var sorted = ApplyGoalieSort(all, effectiveSort, sortDir.Equals("desc", StringComparison.OrdinalIgnoreCase));
+            var paged = sorted.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+            var lastUpdated = await GetLastUpdated(season.Id, ct);
+
+            return new StatsResponse(
+                Section: section,
+                Season: season.Label,
+                SortedBy: effectiveSort,
+                Pagination: new PaginationDto(page, pageSize, all.Count, (int)Math.Ceiling((double)all.Count / pageSize)),
+                DataAsOf: lastUpdated,
+                Players: null,
+                Goalies: paged
+            );
+        }
+        else
+        {
+            var all = await cache.GetOrSetAsync(cacheKey, async _ =>
+            {
+                var items = await BuildQuery(season.Id, section).ToListAsync(ct);
+                return items.Select(MapToSkaterDto).ToList();
+            }, RedisCacheService.StatsTtl, ct) ?? [];
+
+            var sorted = ApplySkaterSort(all, effectiveSort, sortDir.Equals("desc", StringComparison.OrdinalIgnoreCase));
+            var paged = sorted.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+            var lastUpdated = await GetLastUpdated(season.Id, ct);
+
+            return new StatsResponse(
+                Section: section,
+                Season: season.Label,
+                SortedBy: effectiveSort,
+                Pagination: new PaginationDto(page, pageSize, all.Count, (int)Math.Ceiling((double)all.Count / pageSize)),
+                DataAsOf: lastUpdated,
+                Players: paged,
+                Goalies: null
+            );
+        }
+    }
+
+    public bool IsValidSection(string section) => AllSections.Contains(section);
+
+    private IQueryable<PlayerSeason> BuildQuery(int seasonId, string section)
+    {
+        var query = db.PlayerSeasons
+            .Where(ps => ps.SeasonId == seasonId && ps.LeagueAbbreviation == "NHL")
+            .Include(ps => ps.Player)
+            .Include(ps => ps.Team);
+
+        return section.ToLowerInvariant() switch
+        {
+            "all-players" => query.Where(ps => ps.Player.Position != "G"),
+            "all-goalies" => query.Where(ps => ps.Player.Position == "G"),
+            "all-forwards" => query.Where(ps =>
+                ps.Player.Position == "C" || ps.Player.Position == "L" ||
+                ps.Player.Position == "R" || ps.Player.Position == "LW" ||
+                ps.Player.Position == "RW"),
+            "all-defensemen" => query.Where(ps =>
+                ps.Player.Position == "D" || ps.Player.Position == "LD" ||
+                ps.Player.Position == "RD"),
+            "rookie-players" => query.Where(ps =>
+                ps.Player.Position != "G" && ps.GamesPlayed <= 25),
+            "rookie-goalies" => query.Where(ps =>
+                ps.Player.Position == "G" && ps.GamesPlayed <= 25),
+            _ => query
+        };
+    }
+
+    private async Task<DateTimeOffset> GetLastUpdated(int seasonId, CancellationToken ct)
+    {
+        return await db.PlayerSeasons
+            .Where(ps => ps.SeasonId == seasonId && ps.LeagueAbbreviation == "NHL")
+            .MaxAsync(ps => (DateTimeOffset?)ps.LastUpdated, ct) ?? DateTimeOffset.UtcNow;
+    }
+
+    // ── In-memory sorting ────────────────────────────────────────────
+
+    private static List<SkaterStatsDto> ApplySkaterSort(List<SkaterStatsDto> list, string sort, bool desc)
+    {
+        Func<SkaterStatsDto, object?> selector = sort.ToLowerInvariant() switch
+        {
+            "name" => s => s.Name,
+            "team" => s => s.TeamAbbreviation,
+            "gamesplayed" or "gp" => s => s.GamesPlayed,
+            "goals" => s => s.Goals,
+            "assists" => s => s.Assists,
+            "points" => s => s.Points,
+            "plusminus" => s => s.PlusMinus,
+            "hits" => s => s.Hits,
+            "penaltyminutes" or "pim" => s => s.PenaltyMinutes,
+            "timeonice" or "toi" => s => s.TimeOnIcePerGame,
+            "shots" => s => s.Shots,
+            "shootingpct" => s => s.ShootingPct,
+            "blockedshots" => s => s.BlockedShots,
+            "evenstrengthpoints" or "evp" => s => s.EvenStrengthPoints,
+            "powerplaypoints" or "ppp" => s => s.PowerPlayPoints,
+            "shorthandedpoints" or "shp" => s => s.ShortHandedPoints,
+            "giveaways" => s => s.Giveaways,
+            "takeaways" => s => s.Takeaways,
+            "faceoffpct" => s => s.FaceoffPct,
+            _ => s => s.Points
+        };
+
+        return desc
+            ? [.. list.OrderByDescending(selector)]
+            : [.. list.OrderBy(selector)];
+    }
+
+    private static List<GoalieStatsDto> ApplyGoalieSort(List<GoalieStatsDto> list, string sort, bool desc)
+    {
+        Func<GoalieStatsDto, object?> selector = sort.ToLowerInvariant() switch
+        {
+            "name" => g => g.Name,
+            "team" => g => g.TeamAbbreviation,
+            "gamesplayed" or "gp" => g => g.GamesPlayed,
+            "gamesstarted" or "gs" => g => g.GamesStarted,
+            "wins" => g => g.Wins,
+            "losses" => g => g.Losses,
+            "overtimelosses" or "otl" => g => g.OvertimeLosses,
+            "savepct" or "sv%" => g => g.SavePct,
+            // GAA: "desc" (best first) means lowest value first
+            "goalsagainstavg" or "gaa" => g => g.GoalsAgainstAvg,
+            "shotsagainst" => g => g.ShotsAgainst,
+            "saves" => g => g.Saves,
+            "goalsagainst" or "ga" => g => g.GoalsAgainst,
+            "goals" => g => g.Goals,
+            "assists" => g => g.Assists,
+            _ => g => g.Wins
+        };
+
+        // GAA is inverted: "desc" (best first) = lowest GAA
+        var invertGaa = sort.Equals("goalsagainstavg", StringComparison.OrdinalIgnoreCase)
+            || sort.Equals("gaa", StringComparison.OrdinalIgnoreCase);
+
+        var effectiveDesc = invertGaa ? !desc : desc;
+
+        return effectiveDesc
+            ? [.. list.OrderByDescending(selector)]
+            : [.. list.OrderBy(selector)];
+    }
+
+    // ── Mapping ──────────────────────────────────────────────────────
+
+    private static SkaterStatsDto MapToSkaterDto(PlayerSeason ps) => new(
+        PlayerId: int.Parse(ps.Player.ExternalId),
+        Name: $"{ps.Player.FirstName} {ps.Player.LastName}",
+        TeamId: ps.TeamId,
+        TeamAbbreviation: ps.Team.Abbreviation,
+        TeamLogoUrl: ps.Team.LogoUrl,
+        Position: ps.Player.Position,
+        GamesPlayed: ps.GamesPlayed,
+        Goals: ps.Goals,
+        Assists: ps.Assists,
+        Points: ps.Points,
+        PlusMinus: ps.PlusMinus,
+        Hits: ps.Hits,
+        PenaltyMinutes: ps.PenaltyMinutes,
+        TimeOnIcePerGame: ps.TimeOnIcePerGame,
+        Shots: ps.Shots,
+        ShootingPct: ps.ShootingPct,
+        BlockedShots: ps.BlockedShots,
+        EvenStrengthPoints: ps.EvenStrengthPoints,
+        PowerPlayPoints: ps.PowerPlayPoints,
+        ShortHandedPoints: ps.ShortHandedPoints,
+        Giveaways: ps.Giveaways,
+        Takeaways: ps.Takeaways,
+        FaceoffPct: ps.FaceoffPct
+    );
+
+    private static GoalieStatsDto MapToGoalieDto(PlayerSeason ps) => new(
+        PlayerId: int.Parse(ps.Player.ExternalId),
+        Name: $"{ps.Player.FirstName} {ps.Player.LastName}",
+        TeamId: ps.TeamId,
+        TeamAbbreviation: ps.Team.Abbreviation,
+        TeamLogoUrl: ps.Team.LogoUrl,
+        GamesPlayed: ps.GamesPlayed,
+        GamesStarted: ps.GamesStarted,
+        Wins: ps.Wins ?? 0,
+        Losses: ps.Losses ?? 0,
+        OvertimeLosses: ps.OvertimeLosses ?? 0,
+        SavePct: ps.SavePct ?? 0,
+        GoalsAgainstAvg: ps.GoalsAgainstAvg ?? 0,
+        ShotsAgainst: ps.ShotsAgainst ?? 0,
+        Saves: ps.Saves ?? 0,
+        GoalsAgainst: ps.GoalsAgainst ?? 0,
+        Goals: ps.GoalieGoals ?? 0,
+        Assists: ps.GoalieAssists ?? 0
+    );
+}
+
+// ── Response DTOs ────────────────────────────────────────────────
+
+public record StatsResponse(
+    string Section,
+    string Season,
+    string SortedBy,
+    PaginationDto Pagination,
+    DateTimeOffset DataAsOf,
+    IReadOnlyList<SkaterStatsDto>? Players,
+    IReadOnlyList<GoalieStatsDto>? Goalies
+);
+
+public record PaginationDto(
+    int Page,
+    int PageSize,
+    int TotalItems,
+    int TotalPages
+);
+
+public record SkaterStatsDto(
+    int PlayerId,
+    string Name,
+    int TeamId,
+    string TeamAbbreviation,
+    string? TeamLogoUrl,
+    string Position,
+    int GamesPlayed,
+    int Goals,
+    int Assists,
+    int Points,
+    int PlusMinus,
+    int? Hits,
+    int PenaltyMinutes,
+    decimal? TimeOnIcePerGame,
+    int? Shots,
+    decimal? ShootingPct,
+    int? BlockedShots,
+    int? EvenStrengthPoints,
+    int? PowerPlayPoints,
+    int? ShortHandedPoints,
+    int? Giveaways,
+    int? Takeaways,
+    decimal? FaceoffPct
+);
+
+public record GoalieStatsDto(
+    int PlayerId,
+    string Name,
+    int TeamId,
+    string TeamAbbreviation,
+    string? TeamLogoUrl,
+    int GamesPlayed,
+    int? GamesStarted,
+    int Wins,
+    int Losses,
+    int OvertimeLosses,
+    decimal SavePct,
+    decimal GoalsAgainstAvg,
+    int ShotsAgainst,
+    int Saves,
+    int GoalsAgainst,
+    int Goals,
+    int Assists
+);

--- a/backend/src/HockeyHub.Data/Services/Sync/DataSeedService.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/DataSeedService.cs
@@ -140,6 +140,7 @@ public class DataSeedService(
                     Height = p.HeightInches,
                     Weight = p.WeightPounds,
                     ShootsCatches = p.ShootsCatches,
+                    Position = p.Position,
                     JerseyNumber = p.JerseyNumber,
                     CurrentTeamId = team.Id,
                     IsActive = p.IsActive,

--- a/backend/src/HockeyHub.Data/Services/Sync/StatsSyncJob.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/StatsSyncJob.cs
@@ -1,0 +1,203 @@
+using HockeyHub.Core.Models.Entities;
+using HockeyHub.Core.Providers;
+using HockeyHub.Data.Data;
+using HockeyHub.Data.Services.Cache;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HockeyHub.Data.Services.Sync;
+
+public class StatsSyncJob(
+    HockeyHubDbContext db,
+    INhlDataProvider nhlProvider,
+    RedisCacheService cache,
+    ILogger<StatsSyncJob> logger)
+{
+    private static readonly string[] Sections =
+        ["all-players", "all-goalies", "all-forwards", "all-defensemen", "rookie-players", "rookie-goalies"];
+
+    public async Task SyncAsync(CancellationToken ct = default)
+    {
+        logger.LogInformation("Syncing player season stats");
+
+        var league = await db.Leagues.FirstOrDefaultAsync(l => l.Abbreviation == "NHL", ct);
+        if (league is null)
+        {
+            logger.LogError("NHL league not found in database — has DataSeed been run?");
+            return;
+        }
+
+        var season = await db.Seasons
+            .FirstOrDefaultAsync(s => s.LeagueId == league.Id && s.IsCurrent, ct);
+        if (season is null)
+        {
+            logger.LogError("No current season found for NHL — has DataSeed been run?");
+            return;
+        }
+
+        var seasonLabel = $"{season.YearStart}{season.YearEnd}";
+
+        // Fetch skater and goalie stats in sequence (rate limiting handles pacing)
+        var skaterStats = await nhlProvider.GetSkaterStatsAsync(seasonLabel, ct);
+        var goalieStats = await nhlProvider.GetGoalieStatsAsync(seasonLabel, ct);
+
+        if (skaterStats.Count == 0 && goalieStats.Count == 0)
+        {
+            logger.LogWarning("NHL API returned no player stats");
+            return;
+        }
+
+        // Build lookups
+        var teams = await db.Teams
+            .Where(t => t.LeagueId == league.Id)
+            .ToDictionaryAsync(t => t.Abbreviation, ct);
+
+        var players = await db.Players
+            .Where(p => p.IsActive)
+            .ToDictionaryAsync(p => p.ExternalId, ct);
+
+        // Composite key: a player traded mid-season has separate entries per team
+        var existing = await db.PlayerSeasons
+            .Where(ps => ps.SeasonId == season.Id && ps.LeagueAbbreviation == "NHL")
+            .ToDictionaryAsync(ps => (ps.PlayerId, ps.TeamId), ct);
+
+        var synced = 0;
+
+        // ── Sync skater stats ────────────────────────────────────────
+        foreach (var stat in skaterStats)
+        {
+            var externalId = stat.PlayerId.ToString();
+            if (!players.TryGetValue(externalId, out var player)) continue;
+            if (!teams.TryGetValue(stat.TeamAbbreviation, out var team)) continue;
+
+            // Update player position if it has changed
+            if (player.Position != stat.PositionCode)
+                player.Position = stat.PositionCode;
+
+            var key = (player.Id, team.Id);
+            if (existing.TryGetValue(key, out var ps))
+            {
+                ps.GamesPlayed = stat.GamesPlayed;
+                ps.Goals = stat.Goals;
+                ps.Assists = stat.Assists;
+                ps.Points = stat.Points;
+                ps.PlusMinus = stat.PlusMinus;
+                ps.PenaltyMinutes = stat.PenaltyMinutes;
+                ps.Hits = stat.Hits;
+                ps.TimeOnIcePerGame = stat.TimeOnIcePerGame;
+                ps.Shots = stat.Shots;
+                ps.ShootingPct = stat.ShootingPct;
+                ps.BlockedShots = stat.BlockedShots;
+                ps.EvenStrengthPoints = stat.EvenStrengthPoints;
+                ps.PowerPlayPoints = stat.PowerPlayPoints;
+                ps.ShortHandedPoints = stat.ShortHandedPoints;
+                ps.Giveaways = stat.Giveaways;
+                ps.Takeaways = stat.Takeaways;
+                ps.FaceoffPct = stat.FaceoffPct;
+                ps.LastUpdated = DateTimeOffset.UtcNow;
+            }
+            else
+            {
+                var newPs = new PlayerSeason
+                {
+                    PlayerId = player.Id,
+                    TeamId = team.Id,
+                    SeasonId = season.Id,
+                    LeagueAbbreviation = "NHL",
+                    Era = season.Era,
+                    GamesPlayed = stat.GamesPlayed,
+                    Goals = stat.Goals,
+                    Assists = stat.Assists,
+                    Points = stat.Points,
+                    PlusMinus = stat.PlusMinus,
+                    PenaltyMinutes = stat.PenaltyMinutes,
+                    Hits = stat.Hits,
+                    TimeOnIcePerGame = stat.TimeOnIcePerGame,
+                    Shots = stat.Shots,
+                    ShootingPct = stat.ShootingPct,
+                    BlockedShots = stat.BlockedShots,
+                    EvenStrengthPoints = stat.EvenStrengthPoints,
+                    PowerPlayPoints = stat.PowerPlayPoints,
+                    ShortHandedPoints = stat.ShortHandedPoints,
+                    Giveaways = stat.Giveaways,
+                    Takeaways = stat.Takeaways,
+                    FaceoffPct = stat.FaceoffPct,
+                    LastUpdated = DateTimeOffset.UtcNow
+                };
+                db.PlayerSeasons.Add(newPs);
+                existing[key] = newPs;
+            }
+            synced++;
+        }
+
+        // ── Sync goalie stats ────────────────────────────────────────
+        foreach (var stat in goalieStats)
+        {
+            var externalId = stat.PlayerId.ToString();
+            if (!players.TryGetValue(externalId, out var player)) continue;
+            if (!teams.TryGetValue(stat.TeamAbbreviation, out var team)) continue;
+
+            if (player.Position != "G")
+                player.Position = "G";
+
+            var key = (player.Id, team.Id);
+            if (existing.TryGetValue(key, out var ps))
+            {
+                ps.GamesPlayed = stat.GamesPlayed;
+                ps.GamesStarted = stat.GamesStarted;
+                ps.Wins = stat.Wins;
+                ps.Losses = stat.Losses;
+                ps.OvertimeLosses = stat.OvertimeLosses;
+                ps.SavePct = stat.SavePct;
+                ps.GoalsAgainstAvg = stat.GoalsAgainstAvg;
+                ps.ShotsAgainst = stat.ShotsAgainst;
+                ps.Saves = stat.Saves;
+                ps.GoalsAgainst = stat.GoalsAgainst;
+                ps.GoalieGoals = stat.Goals;
+                ps.GoalieAssists = stat.Assists;
+                ps.Goals = stat.Goals;
+                ps.Assists = stat.Assists;
+                ps.Points = stat.Goals + stat.Assists;
+                ps.LastUpdated = DateTimeOffset.UtcNow;
+            }
+            else
+            {
+                var newPs = new PlayerSeason
+                {
+                    PlayerId = player.Id,
+                    TeamId = team.Id,
+                    SeasonId = season.Id,
+                    LeagueAbbreviation = "NHL",
+                    Era = season.Era,
+                    GamesPlayed = stat.GamesPlayed,
+                    GamesStarted = stat.GamesStarted,
+                    Wins = stat.Wins,
+                    Losses = stat.Losses,
+                    OvertimeLosses = stat.OvertimeLosses,
+                    SavePct = stat.SavePct,
+                    GoalsAgainstAvg = stat.GoalsAgainstAvg,
+                    ShotsAgainst = stat.ShotsAgainst,
+                    Saves = stat.Saves,
+                    GoalsAgainst = stat.GoalsAgainst,
+                    GoalieGoals = stat.Goals,
+                    GoalieAssists = stat.Assists,
+                    Goals = stat.Goals,
+                    Assists = stat.Assists,
+                    Points = stat.Goals + stat.Assists,
+                    LastUpdated = DateTimeOffset.UtcNow
+                };
+                db.PlayerSeasons.Add(newPs);
+                existing[key] = newPs;
+            }
+            synced++;
+        }
+
+        await db.SaveChangesAsync(ct);
+
+        // Invalidate all section caches (one key per section)
+        foreach (var section in Sections)
+            await cache.RemoveAsync($"stats:{league.Id}:{section}:{season.Id}", ct);
+
+        logger.LogInformation("Synced stats for {Count} players", synced);
+    }
+}

--- a/frontend/src/app/components/stats/stats-page/stats-page.ts
+++ b/frontend/src/app/components/stats/stats-page/stats-page.ts
@@ -1,7 +1,370 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  inject,
+  signal,
+  computed,
+  OnInit,
+  ChangeDetectionStrategy,
+  DestroyRef,
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  StatsApiService,
+  StatsResponse,
+  StatsSection,
+  SkaterStats,
+  GoalieStats,
+} from '../../../services/stats-api.service';
+import { DEFAULT_LEAGUE_ID } from '../../../constants';
+import { DataAsOf } from '../../shared/data-as-of/data-as-of';
+
+// ── Skater column definitions ────────────────────────────────────
+
+interface ColumnDef<T> {
+  key: string;
+  sortKey: string;
+  label: string;
+  title: string;
+  format?: (row: T) => string;
+  wide?: boolean;
+}
+
+const SKATER_COLUMNS: readonly ColumnDef<SkaterStats>[] = [
+  { key: 'gamesPlayed', sortKey: 'gamesPlayed', label: 'GP', title: 'Games Played' },
+  { key: 'goals', sortKey: 'goals', label: 'G', title: 'Goals' },
+  { key: 'assists', sortKey: 'assists', label: 'A', title: 'Assists' },
+  { key: 'points', sortKey: 'points', label: 'PTS', title: 'Points' },
+  { key: 'plusMinus', sortKey: 'plusMinus', label: '+/-', title: 'Plus/Minus', format: r => formatPlusMinus(r.plusMinus) },
+  { key: 'hits', sortKey: 'hits', label: 'HIT', title: 'Hits', format: r => nullDash(r.hits) },
+  { key: 'penaltyMinutes', sortKey: 'penaltyMinutes', label: 'PIM', title: 'Penalty Minutes' },
+  { key: 'timeOnIcePerGame', sortKey: 'timeOnIce', label: 'TOI', title: 'Time On Ice Per Game', format: r => nullDash(r.timeOnIcePerGame, 1), wide: true },
+  { key: 'shots', sortKey: 'shots', label: 'SOG', title: 'Shots On Goal', format: r => nullDash(r.shots) },
+  { key: 'shootingPct', sortKey: 'shootingPct', label: 'S%', title: 'Shooting %', format: r => nullDash(r.shootingPct, 1), wide: true },
+  { key: 'blockedShots', sortKey: 'blockedShots', label: 'BLK', title: 'Blocked Shots', format: r => nullDash(r.blockedShots) },
+  { key: 'evenStrengthPoints', sortKey: 'evenStrengthPoints', label: 'EVP', title: 'Even Strength Points', format: r => nullDash(r.evenStrengthPoints) },
+  { key: 'powerPlayPoints', sortKey: 'powerPlayPoints', label: 'PPP', title: 'Power Play Points', format: r => nullDash(r.powerPlayPoints) },
+  { key: 'shortHandedPoints', sortKey: 'shortHandedPoints', label: 'SHP', title: 'Short Handed Points', format: r => nullDash(r.shortHandedPoints) },
+  { key: 'giveaways', sortKey: 'giveaways', label: 'GV', title: 'Giveaways', format: r => nullDash(r.giveaways) },
+  { key: 'takeaways', sortKey: 'takeaways', label: 'TK', title: 'Takeaways', format: r => nullDash(r.takeaways) },
+  { key: 'faceoffPct', sortKey: 'faceoffPct', label: 'FO%', title: 'Faceoff Win %', format: r => nullDash(r.faceoffPct, 1), wide: true },
+];
+
+const GOALIE_COLUMNS: readonly ColumnDef<GoalieStats>[] = [
+  { key: 'gamesPlayed', sortKey: 'gamesPlayed', label: 'GP', title: 'Games Played' },
+  { key: 'gamesStarted', sortKey: 'gamesStarted', label: 'GS', title: 'Games Started', format: r => nullDash(r.gamesStarted) },
+  { key: 'wins', sortKey: 'wins', label: 'W', title: 'Wins' },
+  { key: 'losses', sortKey: 'losses', label: 'L', title: 'Losses' },
+  { key: 'overtimeLosses', sortKey: 'overtimeLosses', label: 'OTL', title: 'Overtime Losses' },
+  { key: 'savePct', sortKey: 'savePct', label: 'SV%', title: 'Save %', format: r => r.savePct.toFixed(3).replace(/^0/, ''), wide: true },
+  { key: 'goalsAgainstAvg', sortKey: 'goalsAgainstAvg', label: 'GAA', title: 'Goals Against Average', format: r => r.goalsAgainstAvg.toFixed(2), wide: true },
+  { key: 'shotsAgainst', sortKey: 'shotsAgainst', label: 'SA', title: 'Shots Against' },
+  { key: 'saves', sortKey: 'saves', label: 'SV', title: 'Saves' },
+  { key: 'goalsAgainst', sortKey: 'goalsAgainst', label: 'GA', title: 'Goals Against' },
+  { key: 'goals', sortKey: 'goals', label: 'G', title: 'Goals (Goalie)' },
+  { key: 'assists', sortKey: 'assists', label: 'A', title: 'Assists (Goalie)' },
+];
+
+function nullDash(value: number | null | undefined, decimals?: number): string {
+  if (value === null || value === undefined) return '\u2014';
+  return decimals !== undefined ? value.toFixed(decimals) : value.toString();
+}
+
+function formatPlusMinus(value: number): string {
+  if (value > 0) return `+${value}`;
+  if (value < 0) return `\u2212${Math.abs(value)}`;
+  return '0';
+}
 
 @Component({
   selector: 'app-stats-page',
-  template: `<p>Stats Page — placeholder</p>`
+  imports: [DataAsOf],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="stats-page">
+      <header class="page-header">
+        <h1 class="page-title">{{ data()?.season ?? '...' }} NHL Stats</h1>
+        <p class="page-subtitle">
+          <app-data-as-of [timestamp]="data()?.dataAsOf ?? null" />
+        </p>
+      </header>
+
+      <div class="section-tabs">
+        @for (tab of sections; track tab.value) {
+          <button
+            type="button"
+            [class.active]="section() === tab.value"
+            (click)="setSection(tab.value)">
+            {{ tab.label }}
+          </button>
+        }
+      </div>
+
+      @if (errorMessage()) {
+        <div class="state-message state-error">{{ errorMessage() }}</div>
+      } @else if (loading()) {
+        <div class="state-message">Loading stats...</div>
+      } @else {
+        <div class="table-card">
+          <div class="table-scroll">
+            @if (isGoalieSection()) {
+              <table class="stats-table">
+                <thead>
+                  <tr>
+                    <th class="col-left col-rank-header" title="Rank">#</th>
+                    <th class="col-left col-player-header" title="Player">Player</th>
+                    <th class="col-left col-team-header" title="Team">Team</th>
+                    @for (col of goalieColumns; track col.key) {
+                      <th
+                        [class.sorted]="sortColumn() === col.sortKey"
+                        [class.col-stat-wide]="col.wide"
+                        [title]="col.title"
+                        (click)="toggleSort(col.sortKey)">
+                        {{ col.label }}
+                        @if (sortColumn() === col.sortKey) {
+                          <span class="sort-indicator">{{ sortDir() === 'desc' ? '▼' : '▲' }}</span>
+                        }
+                      </th>
+                    }
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (g of goalies(); track g.playerId; let i = $index) {
+                    <tr [class.row-alt]="i % 2 === 1">
+                      <td class="col-rank">{{ rankNumber(i) }}</td>
+                      <td class="col-left col-player">{{ g.name }}</td>
+                      <td class="col-left col-team">{{ g.teamAbbreviation }}</td>
+                      @for (col of goalieColumns; track col.key) {
+                        <td [class.col-stat-wide]="col.wide">
+                          {{ col.format ? col.format(g) : getGoalieValue(g, col.key) }}
+                        </td>
+                      }
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            } @else {
+              <table class="stats-table">
+                <thead>
+                  <tr>
+                    <th class="col-left col-rank-header" title="Rank">#</th>
+                    <th class="col-left col-player-header" title="Player">Player</th>
+                    <th class="col-left col-team-header" title="Team">Team</th>
+                    <th class="col-pos-header" title="Position">Pos</th>
+                    @for (col of skaterColumns; track col.key) {
+                      <th
+                        [class.sorted]="sortColumn() === col.sortKey"
+                        [class.col-stat-wide]="col.wide"
+                        [title]="col.title"
+                        (click)="toggleSort(col.sortKey)">
+                        {{ col.label }}
+                        @if (sortColumn() === col.sortKey) {
+                          <span class="sort-indicator">{{ sortDir() === 'desc' ? '▼' : '▲' }}</span>
+                        }
+                      </th>
+                    }
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (p of players(); track p.playerId; let i = $index) {
+                    <tr [class.row-alt]="i % 2 === 1">
+                      <td class="col-rank">{{ rankNumber(i) }}</td>
+                      <td class="col-left col-player">{{ p.name }}</td>
+                      <td class="col-left col-team">{{ p.teamAbbreviation }}</td>
+                      <td class="col-pos">{{ p.position }}</td>
+                      @for (col of skaterColumns; track col.key) {
+                        <td [class.col-stat-wide]="col.wide">
+                          {{ col.format ? col.format(p) : getSkaterValue(p, col.key) }}
+                        </td>
+                      }
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            }
+          </div>
+        </div>
+
+        @if (pagination()) {
+          <div class="pagination">
+            <button
+              type="button"
+              [disabled]="page() <= 1"
+              (click)="goToPage(page() - 1)">
+              ← Prev
+            </button>
+            <span class="page-info">
+              Page {{ page() }} of {{ pagination()!.totalPages }}
+              <span class="total-count">({{ pagination()!.totalItems }} players)</span>
+            </span>
+            <button
+              type="button"
+              [disabled]="page() >= (pagination()?.totalPages ?? 1)"
+              (click)="goToPage(page() + 1)">
+              Next →
+            </button>
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [`
+    .stats-page { max-width: 1400px; margin: 0 auto; padding: 28px 20px 48px; font-family: var(--font-primary); }
+    .page-header { margin-bottom: 20px; }
+    .page-title { font-size: 1.2rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-primary); margin: 0 0 4px; }
+    .page-subtitle { font-size: 0.78rem; color: var(--text-muted); margin: 0; min-height: 1.2em; }
+
+    .section-tabs { display: flex; flex-wrap: wrap; gap: 0; margin-bottom: 20px; border: 1px solid var(--border-strong); border-radius: 4px; overflow: hidden; width: fit-content; }
+    .section-tabs button { font: 0.74rem var(--font-primary); padding: 8px 16px; background: var(--bg-card); color: var(--text-secondary); border: none; border-right: 1px solid var(--border-default); cursor: pointer; letter-spacing: 0.02em; white-space: nowrap; }
+    .section-tabs button:last-child { border-right: none; }
+    .section-tabs button:hover { background: var(--bg-row-alt); color: var(--text-primary); }
+    .section-tabs button.active { background: var(--text-primary); color: var(--bg-card); font-weight: 700; }
+
+    .table-card { background: var(--bg-card); border: 1px solid var(--border-default); border-radius: 4px; overflow: hidden; }
+    .table-scroll { overflow-x: auto; }
+
+    .stats-table { width: 100%; border-collapse: collapse; font-size: 0.76rem; }
+    .stats-table th { padding: 8px; text-align: right; font-weight: 700; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.03em; color: var(--text-muted); border-bottom: 2px solid var(--border-strong); cursor: pointer; user-select: none; white-space: nowrap; }
+    .stats-table th:hover { background: var(--bg-row-alt); color: var(--text-primary); }
+    .stats-table th.col-left { text-align: left; }
+    .stats-table th.sorted { color: var(--text-primary); }
+    .stats-table th.col-rank-header { width: 38px; }
+    .stats-table th.col-player-header { width: 180px; }
+    .stats-table th.col-team-header { width: 60px; }
+    .stats-table th.col-pos-header { width: 40px; text-align: center; }
+    .sort-indicator { font-size: 0.62rem; margin-left: 2px; opacity: 0.7; }
+
+    .stats-table tbody td { padding: 6px 8px; text-align: right; border-bottom: 1px solid var(--border-default); white-space: nowrap; font-variant-numeric: tabular-nums; color: var(--text-primary); }
+    .stats-table tbody td.col-left { text-align: left; }
+    .stats-table tbody td.col-rank { text-align: center; color: var(--text-muted); font-size: 0.68rem; }
+    .stats-table tbody td.col-player { font-weight: 700; }
+    .stats-table tbody td.col-team { font-size: 0.72rem; color: var(--text-secondary); }
+    .stats-table tbody td.col-pos { text-align: center; font-size: 0.72rem; color: var(--text-secondary); }
+
+    .stats-table tbody tr.row-alt td { background: var(--bg-row-alt); }
+
+    .pagination { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 16px 0; }
+    .pagination button { font: 700 0.76rem var(--font-primary); padding: 8px 16px; background: var(--bg-card); color: var(--text-primary); border: 1px solid var(--border-strong); border-radius: 4px; cursor: pointer; }
+    .pagination button:hover:not(:disabled) { background: var(--bg-row-alt); }
+    .pagination button:disabled { opacity: 0.4; cursor: default; }
+    .page-info { font-size: 0.78rem; color: var(--text-secondary); }
+    .total-count { color: var(--text-muted); }
+
+    .state-message { color: var(--text-muted); text-align: center; padding: 48px 0; font-size: 14px; }
+    .state-error { color: #c44; }
+
+    @media (max-width: 768px) {
+      .section-tabs { flex-wrap: wrap; width: 100%; }
+      .section-tabs button { flex: 1; min-width: 0; text-align: center; font-size: 0.68rem; padding: 8px 8px; }
+    }
+  `]
 })
-export class StatsPage {}
+export class StatsPage implements OnInit {
+  private route = inject(ActivatedRoute);
+  private api = inject(StatsApiService);
+  private destroyRef = inject(DestroyRef);
+
+  readonly skaterColumns = SKATER_COLUMNS;
+  readonly goalieColumns = GOALIE_COLUMNS;
+
+  readonly sections: { value: StatsSection; label: string }[] = [
+    { value: 'all-players', label: 'All Skaters' },
+    { value: 'all-goalies', label: 'All Goalies' },
+    { value: 'all-forwards', label: 'Forwards' },
+    { value: 'all-defensemen', label: 'Defensemen' },
+    { value: 'rookie-players', label: 'Rookie Skaters' },
+    { value: 'rookie-goalies', label: 'Rookie Goalies' },
+  ];
+
+  leagueId = signal(DEFAULT_LEAGUE_ID);
+  section = signal<StatsSection>('all-players');
+  data = signal<StatsResponse | null>(null);
+  loading = signal(true);
+  errorMessage = signal<string | null>(null);
+  sortColumn = signal<string | null>(null);
+  sortDir = signal<'asc' | 'desc'>('desc');
+  page = signal(1);
+
+  players = computed(() => this.data()?.players ?? []);
+  goalies = computed(() => this.data()?.goalies ?? []);
+  pagination = computed(() => this.data()?.pagination ?? null);
+
+  isGoalieSection = computed(() =>
+    this.section() === 'all-goalies' || this.section() === 'rookie-goalies'
+  );
+
+  ngOnInit(): void {
+    this.route.paramMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      this.leagueId.set(params.get('leagueId') ?? DEFAULT_LEAGUE_ID);
+      this.loadStats();
+    });
+  }
+
+  setSection(section: StatsSection): void {
+    if (this.section() === section) return;
+    this.section.set(section);
+    this.sortColumn.set(null);
+    this.sortDir.set('desc');
+    this.page.set(1);
+    this.loadStats();
+  }
+
+  toggleSort(column: string): void {
+    if (this.sortColumn() === column) {
+      this.sortDir.update(d => d === 'desc' ? 'asc' : 'desc');
+    } else {
+      this.sortColumn.set(column);
+      this.sortDir.set('desc');
+    }
+    this.page.set(1);
+    this.loadStats();
+  }
+
+  goToPage(newPage: number): void {
+    this.page.set(newPage);
+    this.loadStats();
+  }
+
+  rankNumber(index: number): number {
+    const p = this.pagination();
+    if (!p) return index + 1;
+    return (p.page - 1) * p.pageSize + index + 1;
+  }
+
+  getSkaterValue(row: SkaterStats, key: string): string {
+    const val = (row as unknown as Record<string, unknown>)[key];
+    if (val === null || val === undefined) return '\u2014';
+    return String(val);
+  }
+
+  getGoalieValue(row: GoalieStats, key: string): string {
+    const val = (row as unknown as Record<string, unknown>)[key];
+    if (val === null || val === undefined) return '\u2014';
+    return String(val);
+  }
+
+  private loadStats(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    const sort = this.sortColumn() ?? undefined;
+    this.api.getStats(
+      this.leagueId(),
+      this.section(),
+      sort,
+      this.sortDir(),
+      this.page()
+    ).pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: data => {
+        this.data.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.errorMessage.set('Unable to load stats. Please try again.');
+      }
+    });
+  }
+}

--- a/frontend/src/app/services/stats-api.service.ts
+++ b/frontend/src/app/services/stats-api.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../constants';
+
+export type StatsSection =
+  | 'all-players'
+  | 'all-goalies'
+  | 'all-forwards'
+  | 'all-defensemen'
+  | 'rookie-players'
+  | 'rookie-goalies';
+
+export interface StatsResponse {
+  section: string;
+  season: string;
+  sortedBy: string;
+  pagination: Pagination;
+  dataAsOf: string;
+  players: SkaterStats[] | null;
+  goalies: GoalieStats[] | null;
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface SkaterStats {
+  playerId: number;
+  name: string;
+  teamId: number;
+  teamAbbreviation: string;
+  teamLogoUrl: string | null;
+  position: string;
+  gamesPlayed: number;
+  goals: number;
+  assists: number;
+  points: number;
+  plusMinus: number;
+  hits: number | null;
+  penaltyMinutes: number;
+  timeOnIcePerGame: number | null;
+  shots: number | null;
+  shootingPct: number | null;
+  blockedShots: number | null;
+  evenStrengthPoints: number | null;
+  powerPlayPoints: number | null;
+  shortHandedPoints: number | null;
+  giveaways: number | null;
+  takeaways: number | null;
+  faceoffPct: number | null;
+}
+
+export interface GoalieStats {
+  playerId: number;
+  name: string;
+  teamId: number;
+  teamAbbreviation: string;
+  teamLogoUrl: string | null;
+  gamesPlayed: number;
+  gamesStarted: number | null;
+  wins: number;
+  losses: number;
+  overtimeLosses: number;
+  savePct: number;
+  goalsAgainstAvg: number;
+  shotsAgainst: number;
+  saves: number;
+  goalsAgainst: number;
+  goals: number;
+  assists: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class StatsApiService {
+  private http = inject(HttpClient);
+
+  getStats(
+    leagueId: string,
+    section: StatsSection,
+    sort?: string,
+    sortDir: string = 'desc',
+    page: number = 1,
+    pageSize: number = 50
+  ): Observable<StatsResponse> {
+    const params: Record<string, string | number> = {
+      section,
+      sortDir,
+      page,
+      pageSize,
+    };
+    if (sort) params['sort'] = sort;
+
+    return this.http.get<StatsResponse>(
+      `${API_BASE_URL}/api/leagues/${leagueId}/stats`,
+      { params }
+    );
+  }
+}

--- a/frontend/src/app/services/stats-api.service.ts
+++ b/frontend/src/app/services/stats-api.service.ts
@@ -82,9 +82,9 @@ export class StatsApiService {
     leagueId: string,
     section: StatsSection,
     sort?: string,
-    sortDir: string = 'desc',
-    page: number = 1,
-    pageSize: number = 50
+    sortDir = 'desc',
+    page = 1,
+    pageSize = 50
   ): Observable<StatsResponse> {
     const params: Record<string, string | number> = {
       section,

--- a/specs/001-hockey-league-hub/tasks.md
+++ b/specs/001-hockey-league-hub/tasks.md
@@ -199,16 +199,16 @@
 
 ### Backend — US4
 
-- [ ] T074 [P] [US4] Create PlayerSeason entity (with Era, all nullable historical stats, goalie fields) in `backend/src/HockeyHub.Core/Models/Entities/PlayerSeason.cs`
-- [ ] T075 [US4] Add PlayerSeason to DbContext and create migration in `backend/src/HockeyHub.Data/Data/`
-- [ ] T076 [US4] Create StatsQueryService (section filtering, sorting across full dataset, pagination) in `backend/src/HockeyHub.Data/Services/Queries/StatsQueryService.cs`
-- [ ] T077 [US4] Create StatsController with GET stats endpoint (section, sort, sortDir, page, pageSize, season params) per standings-stats-api contract in `backend/src/HockeyHub.Api/Controllers/StatsController.cs`
-- [ ] T078 [US4] Create StatsSyncJob (syncs player season stats, triggered by game events) in `backend/src/HockeyHub.Data/Services/Sync/StatsSyncJob.cs`
+- [x] T074 [P] [US4] Create PlayerSeason entity (with Era, all nullable historical stats, goalie fields) in `backend/src/HockeyHub.Core/Models/Entities/PlayerSeason.cs`
+- [x] T075 [US4] Add PlayerSeason to DbContext and create migration in `backend/src/HockeyHub.Data/Data/`
+- [x] T076 [US4] Create StatsQueryService (section filtering, sorting across full dataset, pagination) in `backend/src/HockeyHub.Data/Services/Queries/StatsQueryService.cs`
+- [x] T077 [US4] Create StatsController with GET stats endpoint (section, sort, sortDir, page, pageSize, season params) per standings-stats-api contract in `backend/src/HockeyHub.Api/Controllers/StatsController.cs`
+- [x] T078 [US4] Create StatsSyncJob (syncs player season stats, triggered by game events) in `backend/src/HockeyHub.Data/Services/Sync/StatsSyncJob.cs`
 
 ### Frontend — US4
 
-- [ ] T079 [US4] Create stats page component (section tabs, stat table with all columns per spec, default sorts, pagination) in `frontend/src/app/components/stats/stats-page/`
-- [ ] T080 [US4] Create stats API service in `frontend/src/app/services/stats-api.service.ts`
+- [x] T079 [US4] Create stats page component (section tabs, stat table with all columns per spec, default sorts, pagination) in `frontend/src/app/components/stats/stats-page/`
+- [x] T080 [US4] Create stats API service in `frontend/src/app/services/stats-api.service.ts`
 
 **Checkpoint**: Stats page with all six sections, sorting, and pagination
 


### PR DESCRIPTION
Backend:
- Add Position field to Player entity (populated from roster + stats APIs)
- Create PlayerSeason entity with skater/goalie stats, EF migration
- Add GetSkaterStatsAsync/GetGoalieStatsAsync to INhlDataProvider
- Implement via NHL Stats REST API (api.nhle.com/stats/rest) with pagination
- StatsSyncJob (Hangfire, every 10min) syncs season stats into DB
- StatsQueryService with 6 section filters, in-memory sort/pagination on cached DTO lists (matching existing query service cache patterns)
- StatsController: GET /api/leagues/{leagueId}/stats
- Composite (PlayerId, TeamId) sync key handles mid-season trades

Frontend:
- StatsApiService with full type definitions
- StatsPage: 6 section tabs (All Skaters, All Goalies, Forwards, Defensemen, Rookie Skaters, Rookie Goalies), sortable column headers, server-side pagination, responsive layout, OnPush + signals