### PR TITLE
Reduce Azure dev costs: SQL Basic tier + smaller Redis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Auto-generated from all feature plans. Last updated: 2026-04-11
 
 ## Active Technologies
 - C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend) + ASP.NET Core 10, Entity Framework Core 10, Hangfire, SignalR, Angular SSR, RxJS, Tailwind CSS v3, Angular CDK (001-hockey-league-hub)
-- SQL Server (Azure SQL Database Serverless for deployed, SQL Server 2022 Developer for local Docker), Redis 7 (cache + pub/sub for real-time) (001-hockey-league-hub)
+- SQL Server (Azure SQL Database Basic for deployed dev, SQL Server 2022 Developer for local Docker), Redis 7 (cache + pub/sub for real-time) (001-hockey-league-hub)
 
 ## Project Structure
 
@@ -102,7 +102,7 @@ az deployment group create -g hockeyhub-dev-rg -f infra/main.bicep -p infra/para
 C# 14 / .NET 10 (backend), TypeScript 5.x / Angular 19 (frontend): Follow standard conventions
 
 ## Deployment Architecture
-- **Azure hosting**: Container Apps (backend API + dev Redis), Azure SQL Database Serverless (GP_S_Gen5_1, auto-pause after 60min idle), Static Web Apps (frontend with CDN), Container Registry, Key Vault, Application Insights
+- **Azure hosting**: Container Apps (backend API + dev Redis), Azure SQL Database Basic (5 DTU, 2GB), Static Web Apps (frontend with CDN), Container Registry, Key Vault, Application Insights
 - **CI/CD**: GitHub Actions — `ci.yml` gates PRs (build/test/lint), `deploy-dev.yml` auto-deploys on merge to main, `deploy-prod.yml` requires manual trigger + approval gate
 - **Health probes**: `HealthController` exposes `/api/health/live` (liveness) and `/api/health/ready` (readiness, checks DB + Redis) — used by Container Apps for revision routing
 - **IaC**: All Azure resources in Bicep templates (`infra/main.bicep`) with env-specific parameter files

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -186,16 +186,13 @@ resource sqlDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = if (isDev)
   location: sqlLocation
   tags: tags
   sku: {
-    name: 'GP_S_Gen5_1'
-    tier: 'GeneralPurpose'
-    family: 'Gen5'
-    capacity: 1
+    name: 'Basic'
+    tier: 'Basic'
+    capacity: 5
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'
-    maxSizeBytes: 34359738368 // 32 GB
-    autoPauseDelay: 60 // Auto-pause after 60 minutes of inactivity
-    minCapacity: json('0.5') // Minimum 0.5 vCores when active
+    maxSizeBytes: 2147483648 // 2 GB (Basic tier max)
     zoneRedundant: false
     requestedBackupStorageRedundancy: 'Local'
   }
@@ -222,8 +219,8 @@ resource redisApp 'Microsoft.App/containerApps@2024-03-01' = if (isDev) {
           name: 'redis'
           image: 'redis:7-alpine'
           resources: {
-            cpu: json('0.25')
-            memory: '0.5Gi'
+            cpu: json('0.125')
+            memory: '0.25Gi'
           }
         }
       ]


### PR DESCRIPTION
SQL Database: GP_S_Gen5_1 Serverless (~$35/mo) → Basic 5 DTU (~$5/mo). Dev DB is 30MB — well within the 2GB Basic limit.

Redis Container App: 0.25 CPU/0.5Gi → 0.125 CPU/0.25Gi. Peak usage is 1.6MB — 256MB is 157x headroom.

Also purged 34 unused ACR image tags (489MB → 247MB).

Projected savings: ~$36/month (~$65 → ~$29).