### PR TITLE
Fix stale game data: reconcile past games stuck as Live/Scheduled

### DIFF
--- a/backend/src/HockeyHub.Data/Services/Sync/ScheduleSyncJob.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/ScheduleSyncJob.cs
@@ -43,17 +43,14 @@ public class ScheduleSyncJob(
             .Where(t => t.LeagueId == league.Id)
             .ToDictionaryAsync(t => t.Abbreviation, ct);
 
-        var existingIds = await db.Games
+        var existingGames = await db.Games
             .Where(g => g.SeasonId == season.Id)
-            .Select(g => g.ExternalId)
-            .ToHashSetAsync(ct);
+            .ToDictionaryAsync(g => g.ExternalId, ct);
 
         var inserted = 0;
+        var updated = 0;
         foreach (var sg in scheduleGames)
         {
-            // Don't touch games that already exist — ScoresSyncJob manages score updates.
-            if (existingIds.Contains(sg.GameId)) continue;
-
             if (!teams.TryGetValue(sg.HomeTeamAbbreviation, out var homeTeam) ||
                 !teams.TryGetValue(sg.AwayTeamAbbreviation, out var awayTeam))
             {
@@ -62,21 +59,35 @@ public class ScheduleSyncJob(
                 continue;
             }
 
-            db.Games.Add(new Game
+            if (existingGames.TryGetValue(sg.GameId, out var existing))
             {
-                ExternalId = sg.GameId,
-                SeasonId = season.Id,
-                HomeTeamId = homeTeam.Id,
-                AwayTeamId = awayTeam.Id,
-                ScheduledStart = sg.ScheduledStart,
-                GameDateLocal = sg.GameDate,
-                Status = sg.Status,
-                LastUpdated = DateTimeOffset.UtcNow
-            });
-            inserted++;
+                // Update status for games that have progressed since they were inserted
+                if (existing.Status != sg.Status)
+                {
+                    existing.Status = sg.Status;
+                    existing.ScheduledStart = sg.ScheduledStart;
+                    existing.LastUpdated = DateTimeOffset.UtcNow;
+                    updated++;
+                }
+            }
+            else
+            {
+                db.Games.Add(new Game
+                {
+                    ExternalId = sg.GameId,
+                    SeasonId = season.Id,
+                    HomeTeamId = homeTeam.Id,
+                    AwayTeamId = awayTeam.Id,
+                    ScheduledStart = sg.ScheduledStart,
+                    GameDateLocal = sg.GameDate,
+                    Status = sg.Status,
+                    LastUpdated = DateTimeOffset.UtcNow
+                });
+                inserted++;
+            }
         }
 
-        if (inserted > 0)
+        if (inserted > 0 || updated > 0)
         {
             await db.SaveChangesAsync(ct);
 
@@ -84,7 +95,7 @@ public class ScheduleSyncJob(
             await cache.RemoveAsync($"schedule:{league.Id}", ct);
         }
 
-        logger.LogInformation("Schedule sync complete: {Inserted} new games inserted ({Total} total in API response)",
-            inserted, scheduleGames.Count);
+        logger.LogInformation("Schedule sync complete: {Inserted} new, {Updated} updated ({Total} total in API response)",
+            inserted, updated, scheduleGames.Count);
     }
 }

--- a/backend/src/HockeyHub.Data/Services/Sync/ScoresSyncJob.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/ScoresSyncJob.cs
@@ -119,6 +119,62 @@ public class ScoresSyncJob(
         await cache.RemoveAsync("scores:live", ct);
 
         logger.LogInformation("Synced {Count} games, {LiveCount} live", nhlGames.Count, liveGames.Count);
+
+        // Reconcile stale games: any Live/Scheduled game whose start is >6 hours ago
+        await ReconcileStaleGamesAsync(league.Id, teams, ct);
+    }
+
+    private async Task ReconcileStaleGamesAsync(int leagueId, Dictionary<string, Team> teams, CancellationToken ct)
+    {
+        var cutoff = DateTimeOffset.UtcNow.AddHours(-6);
+
+        var staleGames = await db.Games
+            .Where(g => g.Season.LeagueId == leagueId
+                && (g.Status == "Live" || g.Status == "Scheduled" || g.Status == "Pre-Game")
+                && g.ScheduledStart < cutoff)
+            .ToListAsync(ct);
+
+        if (staleGames.Count == 0) return;
+
+        logger.LogInformation("Found {Count} stale games to reconcile", staleGames.Count);
+
+        // Group by game date and re-fetch each date from the NHL API
+        var datesToRefresh = staleGames
+            .Select(g => g.GameDateLocal)
+            .Distinct()
+            .ToList();
+
+        foreach (var gameDate in datesToRefresh)
+        {
+            var freshGames = await nhlProvider.GetScoresAsync(gameDate, ct);
+            var freshLookup = freshGames.ToDictionary(g => g.Id);
+
+            var gamesForDate = staleGames.Where(g => g.GameDateLocal == gameDate).ToList();
+            foreach (var stale in gamesForDate)
+            {
+                if (freshLookup.TryGetValue(stale.ExternalId, out var fresh))
+                {
+                    UpdateGame(stale, fresh);
+                    logger.LogInformation("Reconciled game {ExternalId} on {Date}: {OldStatus} → {NewStatus}",
+                        stale.ExternalId, gameDate, "stale", fresh.Status);
+
+                    // Sync detail data for games that finished (to capture final stats)
+                    if (fresh.Status == "Final")
+                    {
+                        await SyncGameDetailAsync(fresh.Id, ct);
+                    }
+                }
+            }
+
+            // Invalidate cache for each reconciled date
+            await cache.RemoveAsync($"scores:{leagueId}:{gameDate:yyyy-MM-dd}", ct);
+        }
+
+        await db.SaveChangesAsync(ct);
+        await cache.RemoveAsync($"scores:ticker:{leagueId}", ct);
+
+        logger.LogInformation("Reconciled {Count} stale games across {DateCount} dates",
+            staleGames.Count, datesToRefresh.Count);
     }
 
     private async Task SyncGameDetailAsync(int externalGameId, CancellationToken ct)


### PR DESCRIPTION
ScoresSyncJob only synced the current game day, so games that were Live when the day rolled over or during server downtime stayed stuck forever. ScheduleSyncJob skipped all existing games entirely, never updating status.

Add ReconcileStaleGamesAsync to ScoresSyncJob: on each 15s cycle, finds any Live/Scheduled/Pre-Game games with start >6h ago, re-fetches from NHL API by date, and updates status + detail stats. No-op when no stale games exist.

Update ScheduleSyncJob to also update existing game status as a daily safety net.