### PR TITLE
Fix dark mode toggle, roster draft data, and Born/Age column label

### DIFF
--- a/backend/src/HockeyHub.Data/Services/Sync/DataSeedService.cs
+++ b/backend/src/HockeyHub.Data/Services/Sync/DataSeedService.cs
@@ -117,6 +117,7 @@ public class DataSeedService(
     private async Task SeedRostersAsync(CancellationToken ct)
     {
         var teams = await db.Teams.Where(t => t.IsActive).ToListAsync(ct);
+        var teamsByAbbrev = teams.ToDictionary(t => t.Abbreviation);
 
         foreach (var team in teams)
         {
@@ -142,6 +143,12 @@ public class DataSeedService(
                     ShootsCatches = p.ShootsCatches,
                     Position = p.Position,
                     JerseyNumber = p.JerseyNumber,
+                    DraftYear = p.DraftYear,
+                    DraftRound = p.DraftRound,
+                    DraftPick = p.DraftPick,
+                    DraftTeamId = p.DraftTeamAbbreviation != null
+                        && teamsByAbbrev.TryGetValue(p.DraftTeamAbbreviation, out var draftTeam)
+                        ? draftTeam.Id : null,
                     CurrentTeamId = team.Id,
                     IsActive = p.IsActive,
                     IsEbug = false

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,9 +1,10 @@
-import { Component, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { Banner } from './components/layout/banner/banner';
 import { ScoreBar } from './components/layout/score-bar/score-bar';
 import { NavBar } from './components/layout/nav-bar/nav-bar';
 import { HamburgerMenu } from './components/layout/hamburger-menu/hamburger-menu';
+import { ThemeService } from './services/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -27,5 +28,6 @@ import { HamburgerMenu } from './components/layout/hamburger-menu/hamburger-menu
   `]
 })
 export class App {
+  private themeService = inject(ThemeService);
   menuOpen = signal(false);
 }

--- a/frontend/src/app/components/teams/team-profile/team-profile.ts
+++ b/frontend/src/app/components/teams/team-profile/team-profile.ts
@@ -76,7 +76,7 @@ import { LoadingText } from '../../shared/loading-text/loading-text';
                     <th class="col-num">#</th>
                     <th class="col-left">Name</th>
                     <th>S/C</th>
-                    <th>Born</th>
+                    <th>Age</th>
                     <th>Birthplace</th>
                     <th>Draft</th>
                   </tr>


### PR DESCRIPTION
- Dark mode: inject ThemeService in root App component so its constructor runs at startup and applies the saved theme to document.documentElement. Previously the service was only instantiated when the hamburger menu opened.

- Draft data: map DraftYear, DraftRound, DraftPick, and DraftTeamId from NhlPlayerData during roster seeding. Fields existed on Player entity but were never populated, causing every player to show "UDFA".

- Rename roster "Born" column to "Age" to match the displayed value (formatAge calculates age, not birth date).